### PR TITLE
ibstat no longer works with ibsim with latest libibumad in rdma-core

### DIFF
--- a/src/ibstat.c
+++ b/src/ibstat.c
@@ -307,6 +307,8 @@ int main(int argc, char *argv[])
 	if (umad_init() < 0)
 		IBPANIC("can't init UMAD library");
 
+	umad_open_port("", 255);
+
 	if ((n = umad_get_cas_names(names, UMAD_MAX_DEVICES)) < 0)
 		IBPANIC("can't list IB device names");
 


### PR DESCRIPTION
If ibstat is run with ibsim, it no longer detects the local ports
with the latest libibumad from rdma-core with the following patch:

commit abf72057c27750275d0668375d30c4971911d041
Author: Jason Gunthorpe <jgg@mellanox.com>
Date:   Thu Apr 5 11:04:14 2018 -0600

    Now that we don't load the umad module if the HW doesn't use it (eg
    for roce only hardware) umad_init is failing to read the ABI version
    from the kernel.

    Applications still want to use some libibumad services that are not
    related to the char device, so move the version check to umad_open_port
    instead.

    Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>

umad_get_cas_names no longer finds any IB devices/ports
when running with ibsim as sysfs is no longer initialized with
the latest libibumad where this is not done as part of umad_init
but moved to umad_open_port.

Fix this by adding dummy umad_open_port call (to IB device and port
that is not possible) which completes the initialization needed after
umad_init in main.

Signed-off-by: Hal Rosenstock <hal@mellanox.com>