### PR TITLE
Add latest Bull device IDs to device white lists

### DIFF
--- a/libibnetdisc/src/ibnetdisc.c
+++ b/libibnetdisc/src/ibnetdisc.c
@@ -206,7 +206,9 @@ static int is_mlnx_ext_port_info_supported(ibnd_port_t * port)
 	     (devid == 0x1b02 || devid == 0x1b50 ||
 	      /* Bull SwitchIB and SwitchIB2 */
 	      devid == 0x1ba0 ||
-	      (devid >= 0x1bd0 && devid <= 0x1bd5))))
+	      (devid >= 0x1bd0 && devid <= 0x1bd5) ||
+	      /* Bull Quantum */
+	      devid == 0x1bf0)))
 		return 1;
 	if ((devid >= 0x1003 && devid <= 0x101b) || (devid == 0xa2d2) ||
 	    ((vendorid == 0x119f) &&
@@ -217,9 +219,9 @@ static int is_mlnx_ext_port_info_supported(ibnd_port_t * port)
 	     /* Bull ConnectIB */
 	      devid == 0x1b83 ||
 	      devid == 0x1b93 || devid == 0x1b94 ||
-	      /* Bull ConnectX4 */
+	      /* Bull ConnectX4, Sequana HDR and HDR100 */
 	      devid == 0x1bb4 || devid == 0x1bb5 ||
-	      devid == 0x1bc4)))
+	      (devid >= 0x1bc4 && devid <= 0x1bc6))))
 		return 1;
 	return 0;
 }

--- a/src/ibdiag_common.c
+++ b/src/ibdiag_common.c
@@ -550,7 +550,9 @@ int is_mlnx_ext_port_info_supported(uint32_t vendorid,
 		     (devid == 0x1b02 || devid == 0x1b50 ||
 		      /* Bull SwitchIB and SwitchIB2 */
 		      devid == 0x1ba0 ||
-		      (devid >= 0x1bd0 && devid <= 0x1bd5))))
+		      (devid >= 0x1bd0 && devid <= 0x1bd5) ||
+		      /* Bull Quantum */
+		      devid == 0x1bf0)))
 			return 1;
 		if ((devid >= 0x1003 && devid <= 0x101b) ||
 		    (devid == 0xa2d2) ||
@@ -562,9 +564,9 @@ int is_mlnx_ext_port_info_supported(uint32_t vendorid,
 		      /* Bull ConnectIB */
 		      devid == 0x1b83 ||
 		      devid == 0x1b93 || devid == 0x1b94 ||
-		      /* Bull ConnectX4 */
+		      /* Bull ConnectX4, Sequana HDR and HDR100 */
 		      devid == 0x1bb4 || devid == 0x1bb5 ||
-		      devid == 0x1bc4)))
+		      (devid >= 0x1bc4 && devid <= 0x1bc6))))
 			return 1;
 	}
 

--- a/src/vendstat.c
+++ b/src/vendstat.c
@@ -155,6 +155,7 @@ static uint16_t ext_fw_info_device[][2] = {
 	{0x1b50, 0x1b50},	/* Bull SwitchX */
 	{0x1ba0, 0x1ba0},	/* Bull SwitchIB */
 	{0x1bd0, 0x1bd5},	/* Bull SwitchIB and SwitchIB2 */
+	{0x1bf0, 0x1bf0},	/* Bull Sequana Quantum */
 	{0x1b33, 0x1b33},	/* Bull ConnectX3 */
 	{0x1b73, 0x1b73},	/* Bull ConnectX3 */
 	{0x1b40, 0x1b41},	/* Bull ConnectX3 */
@@ -162,7 +163,7 @@ static uint16_t ext_fw_info_device[][2] = {
 	{0x1b83, 0x1b83},	/* Bull ConnectIB */
 	{0x1b93, 0x1b94},	/* Bull ConnectIB */
 	{0x1bb4, 0x1bb5},	/* Bull ConnectX4 */
-	{0x1bc4, 0x1bc4},	/* Bull ConnectX4 */
+	{0x1bc4, 0x1bc6},	/* Bull ConnectX4, Sequana HDR and HDR100 */
 	{0x0000, 0x0000}};
 
 static int is_ext_fw_info_supported(uint16_t device_id) {


### PR DESCRIPTION
Sequana HDR adapter: devid = 0x1bc5
Sequana HDR100 adapter: devid = 0x1bc6
Sequana Quantum: devid = 0x1bf0

Signed-off-by: Hal Rosenstock <hal@mellanox.com>