### PR TITLE
Fix warnings in infinbiand-diags

### DIFF
--- a/include/ibdiag_common.h
+++ b/include/ibdiag_common.h
@@ -139,14 +139,14 @@ extern int ibdiag_process_opts(int argc, char *const argv[], void *context,
 			       const char *usage_args,
 			       const char *usage_examples[]);
 extern void ibdiag_show_usage();
-extern void ibexit(const char *fn, char *msg, ...);
+extern void ibexit(const char *fn, const char *msg, ...);
 
 /* convert counter values to a float with a unit specifier returned (using
  * binary prefix)
  * "data" is a flag indicating this counter is a byte counter multiplied by 4
  * as per PortCounters[Extended]
  */
-extern char *conv_cnt_human_readable(uint64_t val64, float *val, int data);
+const char *conv_cnt_human_readable(uint64_t val64, float *val, int data);
 
 int is_mlnx_ext_port_info_supported(uint32_t vendorid, uint16_t devid);
 
@@ -170,13 +170,13 @@ void dump_portinfo(void *pi, int tabs);
 /**
  * Some common command line parsing
  */
-typedef char *(op_fn_t) (ib_portid_t * dest, char **argv, int argc);
+typedef const char *(op_fn_t)(ib_portid_t *dest, char **argv, int argc);
 
 typedef struct match_rec {
 	const char *name, *alias;
 	op_fn_t *fn;
 	unsigned opt_portnum;
-	char *ops_extra;
+	const char *ops_extra;
 } match_rec_t;
 
 op_fn_t *match_op(const match_rec_t match_tbl[], char *name);

--- a/include/ibdiag_common.h
+++ b/include/ibdiag_common.h
@@ -138,7 +138,7 @@ extern int ibdiag_process_opts(int argc, char *const argv[], void *context,
 						      char *optarg),
 			       const char *usage_args,
 			       const char *usage_examples[]);
-extern void ibdiag_show_usage();
+extern void ibdiag_show_usage(void);
 extern void ibexit(const char *fn, const char *msg, ...);
 
 /* convert counter values to a float with a unit specifier returned (using

--- a/libibmad/include/infiniband/mad.h
+++ b/libibmad/include/infiniband/mad.h
@@ -1728,7 +1728,7 @@ extern MAD_EXPORT int ibdebug;
 	exit(-1); \
 } while(0)
 
-MAD_EXPORT void xdump(FILE * file, char *msg, void *p, int size);
+MAD_EXPORT void xdump(FILE * file, const char *msg, void *p, int size);
 
 END_C_DECLS
 #endif				/* _MAD_H_ */

--- a/libibmad/src/dump.c
+++ b/libibmad/src/dump.c
@@ -1195,7 +1195,7 @@ void mad_dump_portinfo_ext(char *buf, int bufsz, void *val, int valsz)
 		     IB_PORT_EXT_HDR_FEC_MODE_LAST_F);
 }
 
-void xdump(FILE * file, char *msg, void *p, int size)
+void xdump(FILE * file, const char *msg, void *p, int size)
 {
 #define HEX(x)  ((x) < 10 ? '0' + (x) : 'a' + ((x) -10))
 	uint8_t *cp = p;

--- a/libibmad/src/fields.c
+++ b/libibmad/src/fields.c
@@ -55,7 +55,7 @@
 #define BE_TO_BITSOFFS(o, w)	(((o) & ~31) | ((32 - ((o) & 31) - (w))))
 
 static const ib_field_t ib_mad_f[] = {
-	{0, 0},			/* IB_NO_FIELD - reserved as invalid */
+	{},			/* IB_NO_FIELD - reserved as invalid */
 
 	{0, 64, "GidPrefix", mad_dump_rhex},
 	{64, 64, "GidGuid", mad_dump_rhex},
@@ -108,7 +108,7 @@ static const ib_field_t ib_mad_f[] = {
 	{56 * 8, (256 - 56) * 8, "SaData", mad_dump_hex},
 
 	/* bytes 64 - 127 */
-	{0, 0},			/* IB_SM_DATA_F - reserved as invalid */
+	{},			/* IB_SM_DATA_F - reserved as invalid */
 
 	/* bytes 64 - 256 */
 	{64 * 8, (256 - 64) * 8, "GsData", mad_dump_hex},
@@ -169,7 +169,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(428, 4), "OverrunErr", mad_dump_uint},
 	{BITSOFFS(432, 16), "MaxCreditHint", mad_dump_uint},
 	{BITSOFFS(456, 24), "RoundTrip", mad_dump_uint},
-	{0, 0},			/* IB_PORT_LAST_F */
+	{},			/* IB_PORT_LAST_F */
 
 	/*
 	 * NodeInfo fields
@@ -186,7 +186,7 @@ static const ib_field_t ib_mad_f[] = {
 	{256, 32, "Revision", mad_dump_hex},
 	{BITSOFFS(288, 8), "LocalPort", mad_dump_uint},
 	{BITSOFFS(296, 24), "VendorId", mad_dump_hex},
-	{0, 0},			/* IB_NODE_LAST_F */
+	{},			/* IB_NODE_LAST_F */
 
 	/*
 	 * SwitchInfo fields
@@ -209,7 +209,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(131, 1), "FilterRawOutbound", mad_dump_uint},
 	{BITSOFFS(132, 1), "EnhancedPort0", mad_dump_uint},
 	{BITSOFFS(144, 16), "MulticastFDBTop", mad_dump_hex},
-	{0, 0},			/* IB_SW_LAST_F */
+	{},			/* IB_SW_LAST_F */
 
 	/*
 	 * SwitchLinearForwardingTable fields
@@ -264,7 +264,7 @@ static const ib_field_t ib_mad_f[] = {
 	{256, 32, "PortXmitPkts", mad_dump_uint},
 	{288, 32, "PortRcvPkts", mad_dump_uint},
 	{320, 32, "PortXmitWait", mad_dump_uint},
-	{0, 0},			/* IB_PC_LAST_F */
+	{},			/* IB_PC_LAST_F */
 
 	/*
 	 * SMInfo
@@ -374,7 +374,7 @@ static const ib_field_t ib_mad_f[] = {
 	{384, 64, "PortUnicastRcvPkts", mad_dump_uint},
 	{448, 64, "PortMulticastXmitPkts", mad_dump_uint},
 	{512, 64, "PortMulticastRcvPkts", mad_dump_uint},
-	{0, 0},			/* IB_PC_EXT_LAST_F */
+	{},			/* IB_PC_EXT_LAST_F */
 
 	/*
 	 * GUIDInfo fields
@@ -426,7 +426,7 @@ static const ib_field_t ib_mad_f[] = {
 	{448, 32, "XmtDataSL13", mad_dump_uint},
 	{480, 32, "XmtDataSL14", mad_dump_uint},
 	{512, 32, "XmtDataSL15", mad_dump_uint},
-	{0, 0},			/* IB_PC_XMT_DATA_SL_LAST_F */
+	{},			/* IB_PC_XMT_DATA_SL_LAST_F */
 
 	/*
 	 * PortRcvDataSL fields
@@ -447,7 +447,7 @@ static const ib_field_t ib_mad_f[] = {
 	{448, 32, "RcvDataSL13", mad_dump_uint},
 	{480, 32, "RcvDataSL14", mad_dump_uint},
 	{512, 32, "RcvDataSL15", mad_dump_uint},
-	{0, 0},			/* IB_PC_RCV_DATA_SL_LAST_F */
+	{},			/* IB_PC_RCV_DATA_SL_LAST_F */
 
 	/*
 	 * PortXmitDiscardDetails fields
@@ -456,7 +456,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(48, 16), "PortNeighborMTUDiscards", mad_dump_uint},
 	{BITSOFFS(64, 16), "PortSwLifetimeLimitDiscards", mad_dump_uint},
 	{BITSOFFS(80, 16), "PortSwHOQLifetimeLimitDiscards", mad_dump_uint},
-	{0, 0},			/* IB_PC_XMT_DISC_LAST_F */
+	{},			/* IB_PC_XMT_DISC_LAST_F */
 
 	/*
 	 * PortRcvErrorDetails fields
@@ -467,7 +467,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(80, 16), "PortDLIDMappingErrors", mad_dump_uint},
 	{BITSOFFS(96, 16), "PortVLMappingErrors", mad_dump_uint},
 	{BITSOFFS(112, 16), "PortLoopingErrors", mad_dump_uint},
-	{0, 0},                 /* IB_PC_RCV_ERR_LAST_F */
+	{},                 /* IB_PC_RCV_ERR_LAST_F */
 
 	/*
 	 * PortSamplesControl fields
@@ -502,7 +502,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(512, 16), "CounterSelect13", mad_dump_hex},
 	{BITSOFFS(528, 16), "CounterSelect14", mad_dump_hex},
 	{576, 64, "SamplesOnlyOptionMask", mad_dump_hex},
-	{0, 0},			/* IB_PSC_LAST_F */
+	{},			/* IB_PSC_LAST_F */
 
 	/* GUIDInfo fields */
 	{0, 64, "GUID0", mad_dump_hex},
@@ -533,7 +533,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(496, 4), "LinkSpeedExtActive", mad_dump_linkspeedext},
 	{BITSOFFS(500, 4), "LinkSpeedExtSupported", mad_dump_linkspeedextsup},
 	{BITSOFFS(507, 5), "LinkSpeedExtEnabled", mad_dump_linkspeedexten},
-	{0, 0},			/* IB_PORT_LINK_SPEED_EXT_LAST_F */
+	{},			/* IB_PORT_LINK_SPEED_EXT_LAST_F */
 
 	/*
 	 * PortExtendedSpeedsCounters fields
@@ -578,21 +578,21 @@ static const ib_field_t ib_mad_f[] = {
 	{1024, 32, "FECUncorrectableBlockCtrLane9", mad_dump_uint},
 	{1056, 32, "FECUncorrectableBlockCtrLane10", mad_dump_uint},
 	{1088, 32, "FECUncorrectableBlockCtrLane11", mad_dump_uint},
-	{0, 0},			/* IB_PESC_LAST_F */
+	{},			/* IB_PESC_LAST_F */
 
 	/*
 	 * PortOpRcvCounters fields
 	 */
 	{32, 32, "PortOpRcvPkts", mad_dump_uint},
 	{64, 32, "PortOpRcvData", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_OP_RCV_COUNTERS_LAST_F */
+	{},			/* IB_PC_PORT_OP_RCV_COUNTERS_LAST_F */
 
 	/*
 	 * PortFlowCtlCounters fields
 	 */
 	{32, 32, "PortXmitFlowPkts", mad_dump_uint},
 	{64, 32, "PortRcvFlowPkts", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_FLOW_CTL_COUNTERS_LAST_F */
+	{},			/* IB_PC_PORT_FLOW_CTL_COUNTERS_LAST_F */
 
 	/*
 	 * PortVLOpPackets fields
@@ -613,7 +613,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(240, 16), "PortVLOpPackets13", mad_dump_uint},
 	{BITSOFFS(256, 16), "PortVLOpPackets14", mad_dump_uint},
 	{BITSOFFS(272, 16), "PortVLOpPackets15", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_VL_OP_PACKETS_LAST_F */
+	{},			/* IB_PC_PORT_VL_OP_PACKETS_LAST_F */
 
 	/*
 	 * PortVLOpData fields
@@ -634,7 +634,7 @@ static const ib_field_t ib_mad_f[] = {
 	{448, 32, "PortVLOpData13", mad_dump_uint},
 	{480, 32, "PortVLOpData14", mad_dump_uint},
 	{512, 32, "PortVLOpData15", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_VL_OP_DATA_LAST_F */
+	{},			/* IB_PC_PORT_VL_OP_DATA_LAST_F */
 
 	/*
 	 * PortVLXmitFlowCtlUpdateErrors fields
@@ -655,7 +655,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(58, 2), "PortVLXmitFlowCtlUpdateErrors13", mad_dump_uint},
 	{BITSOFFS(60, 2), "PortVLXmitFlowCtlUpdateErrors14", mad_dump_uint},
 	{BITSOFFS(62, 2), "PortVLXmitFlowCtlUpdateErrors15", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_VL_XMIT_FLOW_CTL_UPDATE_ERRORS_LAST_F */
+	{},			/* IB_PC_PORT_VL_XMIT_FLOW_CTL_UPDATE_ERRORS_LAST_F */
 
 	/*
 	 * PortVLXmitWaitCounters fields
@@ -676,7 +676,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(240, 16), "PortVLXmitWait13", mad_dump_uint},
 	{BITSOFFS(256, 16), "PortVLXmitWait14", mad_dump_uint},
 	{BITSOFFS(272, 16), "PortVLXmitWait15", mad_dump_uint},
-	{0, 0},			/* IB_PC_PORT_VL_XMIT_WAIT_COUNTERS_LAST_F */
+	{},			/* IB_PC_PORT_VL_XMIT_WAIT_COUNTERS_LAST_F */
 
 	/*
 	 * SwPortVLCongestion fields
@@ -697,14 +697,14 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(240, 16), "SWPortVLCongestion13", mad_dump_uint},
 	{BITSOFFS(256, 16), "SWPortVLCongestion14", mad_dump_uint},
 	{BITSOFFS(272, 16), "SWPortVLCongestion15", mad_dump_uint},
-	{0, 0},			/* IB_PC_SW_PORT_VL_CONGESTION_LAST_F */
+	{},			/* IB_PC_SW_PORT_VL_CONGESTION_LAST_F */
 
 	/*
 	 * PortRcvConCtrl fields
 	 */
 	{32, 32, "PortPktRcvFECN", mad_dump_uint},
 	{64, 32, "PortPktRcvBECN", mad_dump_uint},
-	{0, 0},			/* IB_PC_RCV_CON_CTRL_LAST_F */
+	{},			/* IB_PC_RCV_CON_CTRL_LAST_F */
 
 	/*
 	 * PortSLRcvFECN fields
@@ -725,7 +725,7 @@ static const ib_field_t ib_mad_f[] = {
 	{448, 32, "PortSLRcvFECN13", mad_dump_uint},
 	{480, 32, "PortSLRcvFECN14", mad_dump_uint},
 	{512, 32, "PortSLRcvFECN15", mad_dump_uint},
-	{0, 0},			/* IB_PC_SL_RCV_FECN_LAST_F */
+	{},			/* IB_PC_SL_RCV_FECN_LAST_F */
 
 	/*
 	 * PortSLRcvBECN fields
@@ -746,13 +746,13 @@ static const ib_field_t ib_mad_f[] = {
 	{448, 32, "PortSLRcvBECN13", mad_dump_uint},
 	{480, 32, "PortSLRcvBECN14", mad_dump_uint},
 	{512, 32, "PortSLRcvBECN15", mad_dump_uint},
-	{0, 0},			/* IB_PC_SL_RCV_BECN_LAST_F */
+	{},			/* IB_PC_SL_RCV_BECN_LAST_F */
 
 	/*
 	 * PortXmitConCtrl fields
 	 */
 	{32, 32, "PortXmitTimeCong", mad_dump_uint},
-	{0, 0},			/* IB_PC_XMIT_CON_CTRL_LAST_F */
+	{},			/* IB_PC_XMIT_CON_CTRL_LAST_F */
 
 	/*
 	 * PortVLXmitTimeCong fields
@@ -772,7 +772,7 @@ static const ib_field_t ib_mad_f[] = {
 	{416, 32, "PortVLXmitTimeCong12", mad_dump_uint},
 	{448, 32, "PortVLXmitTimeCong13", mad_dump_uint},
 	{480, 32, "PortVLXmitTimeCong14", mad_dump_uint},
-	{0, 0},			/* IB_PC_VL_XMIT_TIME_CONG_LAST_F */
+	{},			/* IB_PC_VL_XMIT_TIME_CONG_LAST_F */
 
 	/*
 	 * Mellanox ExtendedPortInfo fields
@@ -781,7 +781,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(56, 8), "LinkSpeedSupported", mad_dump_hex},
 	{BITSOFFS(88, 8), "LinkSpeedEnabled", mad_dump_hex},
 	{BITSOFFS(120, 8), "LinkSpeedActive", mad_dump_hex},
-	{0, 0},			/* IB_MLNX_EXT_PORT_LAST_F */
+	{},			/* IB_MLNX_EXT_PORT_LAST_F */
 
 	/*
 	 * Congestion Control Mad fields
@@ -794,7 +794,7 @@ static const ib_field_t ib_mad_f[] = {
 	 */
 	{BITSOFFS(0, 16), "CongestionInfo", mad_dump_hex},
 	{BITSOFFS(16, 8), "ControlTableCap", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_INFO_LAST_F */
+	{},			/* IB_CC_CONGESTION_INFO_LAST_F */
 
 	/*
 	 * CongestionKeyInfo fields
@@ -803,14 +803,14 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(64, 1), "CC_KeyProtectBit", mad_dump_uint},
 	{BITSOFFS(80, 16), "CC_KeyLeasePeriod", mad_dump_uint},
 	{BITSOFFS(96, 16), "CC_KeyViolations", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_KEY_INFO_LAST_F */
+	{},			/* IB_CC_CONGESTION_KEY_INFO_LAST_F */
 
 	/*
 	 * CongestionLog (common) fields
 	 */
 	{BITSOFFS(0, 8), "LogType", mad_dump_uint},
 	{BITSOFFS(8, 8), "CongestionFlags", mad_dump_hex},
-	{0, 0},			/* IB_CC_CONGESTION_LOG_LAST_F */
+	{},			/* IB_CC_CONGESTION_LOG_LAST_F */
 
 	/*
 	 * CongestionLog (Switch) fields
@@ -818,7 +818,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(16, 16), "LogEventsCounter", mad_dump_uint},
 	{32, 32, "CurrentTimeStamp", mad_dump_uint},
 	{64, 256, "PortMap", mad_dump_array},
-	{0, 0},			/* IB_CC_CONGESTION_LOG_SWITCH_LAST_F */
+	{},			/* IB_CC_CONGESTION_LOG_SWITCH_LAST_F */
 
 	/*
 	 * CongestionLogEvent (Switch) fields
@@ -827,7 +827,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(16, 16), "DLID", mad_dump_uint},
 	{BITSOFFS(32, 4), "SL", mad_dump_uint},
 	{64, 32, "Timestamp", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_LOG_ENTRY_SWITCH_LAST_F */
+	{},			/* IB_CC_CONGESTION_LOG_ENTRY_SWITCH_LAST_F */
 
 	/*
 	 * CongestionLog (CA) fields
@@ -838,7 +838,7 @@ static const ib_field_t ib_mad_f[] = {
 	 * word aligned.  Assume will be aligned to offset 64 later.
 	 */
 	{BITSOFFS(64, 32), "CurrentTimeStamp", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_LOG_CA_LAST_F */
+	{},			/* IB_CC_CONGESTION_LOG_CA_LAST_F */
 
 	/*
 	 * CongestionLogEvent (CA) fields
@@ -850,7 +850,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(64, 16), "Local_LID_CN", mad_dump_uint},
 	{BITSOFFS(80, 16), "Remote_LID_CN_Entry", mad_dump_uint},
 	{BITSOFFS(96, 32), "Timestamp_CN_Entry", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_LOG_ENTRY_CA_LAST_F */
+	{},			/* IB_CC_CONGESTION_LOG_ENTRY_CA_LAST_F */
 
 	/*
 	 * SwitchCongestionSetting fields
@@ -863,7 +863,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(560, 4), "CS_Threshold", mad_dump_hex},
 	{BITSOFFS(576, 16), "CS_ReturnDelay", mad_dump_hex}, /* TODO: CCT dump */
 	{BITSOFFS(592, 16), "Marking_Rate", mad_dump_uint},
-	{0, 0},			/* IB_CC_SWITCH_CONGESTION_SETTING_LAST_F */
+	{},			/* IB_CC_SWITCH_CONGESTION_SETTING_LAST_F */
 
 	/*
 	 * SwitchPortCongestionSettingElement fields
@@ -873,14 +873,14 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(4, 4), "Threshold", mad_dump_hex},
 	{BITSOFFS(8, 8), "Packet_Size", mad_dump_uint},
 	{BITSOFFS(16, 16), "Cong_Parm_Marking_Rate", mad_dump_uint},
-	{0, 0},			/* IB_CC_SWITCH_PORT_CONGESTION_SETTING_ELEMENT_LAST_F */
+	{},			/* IB_CC_SWITCH_PORT_CONGESTION_SETTING_ELEMENT_LAST_F */
 
 	/*
 	 * CACongestionSetting fields
 	 */
 	{BITSOFFS(0, 16), "Port_Control", mad_dump_hex},
 	{BITSOFFS(16, 16), "Control_Map", mad_dump_hex},
-	{0, 0},			/* IB_CC_CA_CONGESTION_SETTING_LAST_F */
+	{},			/* IB_CC_CA_CONGESTION_SETTING_LAST_F */
 
 	/*
 	 * CACongestionEntry fields
@@ -889,26 +889,26 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(16, 8), "CCTI_Increase", mad_dump_uint},
 	{BITSOFFS(24, 8), "Trigger_Threshold", mad_dump_uint},
 	{BITSOFFS(32, 8), "CCTI_Min", mad_dump_uint},
-	{0, 0},			/* IB_CC_CA_CONGESTION_SETTING_ENTRY_LAST_F */
+	{},			/* IB_CC_CA_CONGESTION_SETTING_ENTRY_LAST_F */
 
 	/*
 	 * CongestionControlTable fields
 	 */
 	{BITSOFFS(0, 16), "CCTI_Limit", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_CONTROL_TABLE_LAST_F */
+	{},			/* IB_CC_CONGESTION_CONTROL_TABLE_LAST_F */
 
 	/*
 	 * CongestionControlTableEntry fields
 	 */
 	{BITSOFFS(0, 2), "CCT_Shift", mad_dump_uint},
 	{BITSOFFS(2, 14), "CCT_Multiplier", mad_dump_uint},
-	{0, 0},			/* IB_CC_CONGESTION_CONTROL_TABLE_ENTRY_LAST_F */
+	{},			/* IB_CC_CONGESTION_CONTROL_TABLE_ENTRY_LAST_F */
 
 	/*
 	 * Timestamp fields
 	 */
 	{0, 32, "Timestamp", mad_dump_uint},
-	{0, 0}, /* IB_CC_TIMESTAMP_LAST_F */
+	{}, /* IB_CC_TIMESTAMP_LAST_F */
 
 	/* Node Record */
 	{BITSOFFS(0, 16), "Lid", mad_dump_uint},
@@ -925,7 +925,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(320, 8), "LocalPort", mad_dump_uint},
 	{BITSOFFS(328, 24), "VendorId", mad_dump_hex},
 	{352, 64 * 8, "NodeDesc", mad_dump_string},
-	{0, 0}, /* IB_SA_NR_LAST_F */
+	{}, /* IB_SA_NR_LAST_F */
 
 	/*
 	 * PortSamplesResult fields
@@ -947,7 +947,7 @@ static const ib_field_t ib_mad_f[] = {
 	{416, 32, "Counter12", mad_dump_uint},
 	{448, 32, "Counter13", mad_dump_uint},
 	{480, 32, "Counter14", mad_dump_uint},
-	{0, 0},			/* IB_PSR_LAST_F */
+	{},			/* IB_PSR_LAST_F */
 
 	/*
 	 * PortInfoExtended fields
@@ -958,7 +958,7 @@ static const ib_field_t ib_mad_f[] = {
 	{BITSOFFS(64, 16), "FDRFECModeEnabled", mad_dump_hex},
 	{BITSOFFS(80, 16), "EDRFECModeSupported", mad_dump_hex},
 	{BITSOFFS(96, 16), "EDRFECModeEnabled", mad_dump_hex},
-	{0, 0},			/* IB_PORT_EXT_LAST_F */
+	{},			/* IB_PORT_EXT_LAST_F */
 
 	/*
 	 * PortExtendedSpeedsCounters RSFEC Active fields
@@ -982,7 +982,7 @@ static const ib_field_t ib_mad_f[] = {
 	{1120, 32, "PortFECCorrectableBlockCtr", mad_dump_uint},
 	{1152, 32, "PortFECUncorrectableBlockCtr", mad_dump_uint},
 	{1184, 32, "PortFECCorrectedSymbolCtr", mad_dump_uint},
-	{0, 0},			/* IB_PESC_RSFEC_LAST_F */
+	{},			/* IB_PESC_RSFEC_LAST_F */
 
 	/*
 	 * More PortCountersExtended fields
@@ -1002,7 +1002,7 @@ static const ib_field_t ib_mad_f[] = {
 	{1280, 64, "VL15Dropped", mad_dump_uint},
 	{1344, 64, "PortXmitWait", mad_dump_uint},
 	{1408, 64, "QP1Dropped", mad_dump_uint},
-	{0, 0},			/* IB_PC_EXT_ERR_LAST_F */
+	{},			/* IB_PC_EXT_ERR_LAST_F */
 
 	/*
 	 * Another PortCounters field
@@ -1014,9 +1014,9 @@ static const ib_field_t ib_mad_f[] = {
 	 */
 	{112, 16, "HDRFECModeSupported", mad_dump_hex},
 	{128, 16, "HDRFECModeEnabled", mad_dump_hex},
-	{0, 0},			/* IB_PORT_EXT_HDR_FEC_MODE_LAST_F */
+	{},			/* IB_PORT_EXT_HDR_FEC_MODE_LAST_F */
 
-	{0, 0}			/* IB_FIELD_LAST_ */
+	{}			/* IB_FIELD_LAST_ */
 };
 
 static void _set_field64(void *buf, int base_offs, const ib_field_t * f,

--- a/libibmad/src/libibmad.map
+++ b/libibmad/src/libibmad.map
@@ -111,7 +111,6 @@ IBMAD_1.3 {
 		mad_get_timeout;
 		mad_get_retries;
 		madrpc;
-		madrpc_def_timeout;
 		madrpc_init;
 		madrpc_portid;
 		madrpc_rmpp;

--- a/libibmad/src/rpc.c
+++ b/libibmad/src/rpc.c
@@ -103,11 +103,6 @@ void mad_rpc_set_timeout(struct ibmad_port *port, int timeout)
 	port->timeout = timeout;
 }
 
-int madrpc_def_timeout(void)
-{
-	return madrpc_timeout;
-}
-
 int madrpc_portid(void)
 {
 	return ibmp->port_id;

--- a/libibnetdisc/include/infiniband/ibnetdisc.h
+++ b/libibnetdisc/include/infiniband/ibnetdisc.h
@@ -243,7 +243,7 @@ IBND_EXPORT void ibnd_iter_ports(ibnd_fabric_t * fabric,
  */
 IBND_EXPORT uint64_t ibnd_get_chassis_guid(ibnd_fabric_t * fabric,
 					  unsigned char chassisnum);
-IBND_EXPORT char *ibnd_get_chassis_type(ibnd_node_t * node);
+IBND_EXPORT const char *ibnd_get_chassis_type(ibnd_node_t *node);
 IBND_EXPORT char *ibnd_get_chassis_slot_str(ibnd_node_t * node,
 					   char *str, size_t size);
 

--- a/libibnetdisc/src/chassis.c
+++ b/libibnetdisc/src/chassis.c
@@ -354,11 +354,6 @@ static int is_line(ibnd_node_t * n)
 		is_line_2024(n) || is_line_4700(n));
 }
 
-int is_chassis_switch(ibnd_node_t * n)
-{
-	return (is_spine(n) || is_line(n));
-}
-
 /* these structs help find Line (Anafa) slot number while using spine portnum */
 char line_slot_2_sfb4[37] = {
 	0,

--- a/libibnetdisc/src/chassis.c
+++ b/libibnetdisc/src/chassis.c
@@ -50,9 +50,9 @@
 #include "internal.h"
 #include "chassis.h"
 
-static char *ChassisTypeStr[] =
+static const char * const ChassisTypeStr[] =
 { "", "ISR9288", "ISR9096", "ISR2012", "ISR2004", "ISR4700", "ISR4200" };
-static char *ChassisSlotTypeStr[] = { "", "Line", "Spine", "SRBD" };
+static const char * const ChassisSlotTypeStr[] = { "", "Line", "Spine", "SRBD" };
 
 typedef struct chassis_scan {
 	ibnd_chassis_t *first_chassis;
@@ -60,7 +60,7 @@ typedef struct chassis_scan {
 	ibnd_chassis_t *last_chassis;
 } chassis_scan_t;
 
-char *ibnd_get_chassis_type(ibnd_node_t * node)
+const char *ibnd_get_chassis_type(ibnd_node_t * node)
 {
 	int chassis_type;
 

--- a/libibnetdisc/src/ibnetdisc.c
+++ b/libibnetdisc/src/ibnetdisc.c
@@ -515,8 +515,8 @@ static void link_ports(ibnd_node_t * node, ibnd_port_t * port,
 	remoteport->remoteport = port;
 }
 
-static void dump_endnode(ib_portid_t * path, char *prompt,
-			 ibnd_node_t * node, ibnd_port_t * port)
+static void dump_endnode(ib_portid_t *path, const char *prompt,
+			 ibnd_node_t *node, ibnd_port_t *port)
 {
 	char type[64];
 	mad_dump_node_type(type, sizeof(type), &node->type, sizeof(int));

--- a/libibnetdisc/src/ibnetdisc.c
+++ b/libibnetdisc/src/ibnetdisc.c
@@ -65,7 +65,6 @@ static int query_node_info(smp_engine_t * engine, ib_portid_t * portid,
 			   struct ni_cbdata * cbdata);
 static int query_port_info(smp_engine_t * engine, ib_portid_t * portid,
 			   ibnd_node_t * node, int portnum);
-ibnd_port_t *ibnd_find_port_dr(ibnd_fabric_t * fabric, char *dr_str);
 
 static int recv_switch_info(smp_engine_t * engine, ibnd_smp_t * smp,
 			    uint8_t * mad, void *cb_data)

--- a/libibnetdisc/src/internal.h
+++ b/libibnetdisc/src/internal.h
@@ -114,4 +114,7 @@ void add_to_type_list(ibnd_node_t * node, f_internal_t * fabric);
 
 void destroy_node(ibnd_node_t * node);
 
+int mlnx_ext_port_info_err(smp_engine_t *engine, ibnd_smp_t *smp, uint8_t *mad,
+			   void *cb_data);
+
 #endif				/* _INTERNAL_H_ */

--- a/libibnetdisc/src/query_smp.c
+++ b/libibnetdisc/src/query_smp.c
@@ -41,9 +41,6 @@
 #include <infiniband/umad.h>
 #include "internal.h"
 
-extern int mlnx_ext_port_info_err(smp_engine_t * engine, ibnd_smp_t * smp,
-				  uint8_t * mad, void *cb_data);
-
 static void queue_smp(smp_engine_t * engine, ibnd_smp_t * smp)
 {
 	smp->qnext = NULL;

--- a/libibnetdisc/test/testleaks.c
+++ b/libibnetdisc/test/testleaks.c
@@ -54,7 +54,7 @@
 const char *argv0 = "iblinkinfotest";
 static FILE *f;
 
-void usage(void)
+static void usage(void)
 {
 	fprintf(stderr,
 		"Usage: %s [-hclp -D <direct route> -C <ca_name> -P <ca_port>]\n"

--- a/libibnetdisc/test/testleaks.c
+++ b/libibnetdisc/test/testleaks.c
@@ -51,7 +51,7 @@
 #include <infiniband/complib/cl_nodenamemap.h>
 #include <infiniband/ibnetdisc.h>
 
-char *argv0 = "iblinkinfotest";
+const char *argv0 = "iblinkinfotest";
 static FILE *f;
 
 void usage(void)

--- a/src/dump_fts.c
+++ b/src/dump_fts.c
@@ -65,8 +65,8 @@ static nn_map_t *node_name_map = NULL;
 
 #define IB_MLIDS_IN_BLOCK	(IB_SMP_DATA_SIZE/2)
 
-int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
-	      uint16_t mft[16][IB_MLIDS_IN_BLOCK])
+static int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
+		     uint16_t mft[16][IB_MLIDS_IN_BLOCK])
 {
 	uint16_t mask;
 	unsigned i, chunk, bit, nonzero = 0;
@@ -110,8 +110,8 @@ int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
 
 uint16_t mft[16][IB_MLIDS_IN_BLOCK] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0}, { 0 }, { 0 } };
 
-void dump_multicast_tables(ibnd_node_t * node, unsigned startlid,
-			    unsigned endlid, struct ibmad_port * mad_port)
+static void dump_multicast_tables(ibnd_node_t *node, unsigned startlid,
+				  unsigned endlid, struct ibmad_port *mad_port)
 {
 	ib_portid_t *portid = &node->path_portid;
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
@@ -225,10 +225,9 @@ void dump_multicast_tables(ibnd_node_t * node, unsigned startlid,
 	free(mapnd);
 }
 
-int dump_lid(char *str, int str_len, int lid, int valid,
-		ibnd_fabric_t *fabric,
-		int * last_port_lid, int * base_port_lid,
-		uint64_t * portguid)
+static int dump_lid(char *str, int str_len, int lid, int valid,
+		    ibnd_fabric_t *fabric, int *last_port_lid,
+		    int *base_port_lid, uint64_t *portguid)
 {
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
 
@@ -302,8 +301,9 @@ int dump_lid(char *str, int str_len, int lid, int valid,
 	return rc;
 }
 
-void dump_unicast_tables(ibnd_node_t * node, int startlid, int endlid,
-			struct ibmad_port *mad_port, ibnd_fabric_t *fabric)
+static void dump_unicast_tables(ibnd_node_t *node, int startlid, int endlid,
+				struct ibmad_port *mad_port,
+				ibnd_fabric_t *fabric)
 {
 	ib_portid_t * portid = &node->path_portid;
 	char lft[IB_SMP_DATA_SIZE] = { 0 };
@@ -379,8 +379,8 @@ void dump_unicast_tables(ibnd_node_t * node, int startlid, int endlid,
 	free(mapnd);
 }
 
-void dump_node(ibnd_node_t *node, struct ibmad_port *mad_port,
-		ibnd_fabric_t *fabric)
+static void dump_node(ibnd_node_t *node, struct ibmad_port *mad_port,
+		      ibnd_fabric_t *fabric)
 {
 	if (multicast)
 		dump_multicast_tables(node, startlid, endlid, mad_port);
@@ -389,7 +389,7 @@ void dump_node(ibnd_node_t *node, struct ibmad_port *mad_port,
 						mad_port, fabric);
 }
 
-void process_switch(ibnd_node_t * node, void *fabric)
+static void process_switch(ibnd_node_t *node, void *fabric)
 {
 	dump_node(node, srcport, (ibnd_fabric_t *)fabric);
 }

--- a/src/dump_fts.c
+++ b/src/dump_fts.c
@@ -110,8 +110,8 @@ static int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
 
 uint16_t mft[16][IB_MLIDS_IN_BLOCK] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0}, { 0 }, { 0 } };
 
-static void dump_multicast_tables(ibnd_node_t *node, unsigned startlid,
-				  unsigned endlid, struct ibmad_port *mad_port)
+static void dump_multicast_tables(ibnd_node_t *node, unsigned startl,
+				  unsigned endl, struct ibmad_port *mad_port)
 {
 	ib_portid_t *portid = &node->path_portid;
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
@@ -131,33 +131,33 @@ static void dump_multicast_tables(ibnd_node_t *node, unsigned startlid,
 	mad_decode_field(node->switchinfo, IB_SW_MCAST_FDB_CAP_F, &cap);
 	mad_decode_field(node->switchinfo, IB_SW_MCAST_FDB_TOP_F, &top);
 
-	if (!endlid || endlid > IB_MIN_MCAST_LID + cap - 1)
-		endlid = IB_MIN_MCAST_LID + cap - 1;
-	if (!dump_all && top && top < endlid) {
+	if (!endl || endl > IB_MIN_MCAST_LID + cap - 1)
+		endl = IB_MIN_MCAST_LID + cap - 1;
+	if (!dump_all && top && top < endl) {
 		if (top < IB_MIN_MCAST_LID - 1)
 			IBWARN("illegal top mlid %x", top);
 		else
-			endlid = top;
+			endl = top;
 	}
 
-	if (!startlid)
-		startlid = IB_MIN_MCAST_LID;
-	else if (startlid < IB_MIN_MCAST_LID) {
-		IBWARN("illegal start mlid %x, set to %x", startlid,
+	if (!startl)
+		startl = IB_MIN_MCAST_LID;
+	else if (startl < IB_MIN_MCAST_LID) {
+		IBWARN("illegal start mlid %x, set to %x", startl,
 		       IB_MIN_MCAST_LID);
-		startlid = IB_MIN_MCAST_LID;
+		startl = IB_MIN_MCAST_LID;
 	}
 
-	if (endlid > IB_MAX_MCAST_LID) {
-		IBWARN("illegal end mlid %x, truncate to %x", endlid,
+	if (endl > IB_MAX_MCAST_LID) {
+		IBWARN("illegal end mlid %x, truncate to %x", endl,
 		       IB_MAX_MCAST_LID);
-		endlid = IB_MAX_MCAST_LID;
+		endl = IB_MAX_MCAST_LID;
 	}
 
 	mapnd = remap_node_name(node_name_map, nodeguid, nd);
 
 	printf("Multicast mlids [0x%x-0x%x] of switch %s guid 0x%016" PRIx64
-	       " (%s):\n", startlid, endlid, portid2str(portid), nodeguid,
+	       " (%s):\n", startl, endl, portid2str(portid), nodeguid,
 	       mapnd);
 
 	if (brief)
@@ -182,8 +182,8 @@ static void dump_multicast_tables(ibnd_node_t *node, unsigned startlid,
 
 	chunks = ALIGN(nports + 1, 16) / 16;
 
-	startblock = startlid / IB_MLIDS_IN_BLOCK;
-	lastblock = endlid / IB_MLIDS_IN_BLOCK;
+	startblock = startl / IB_MLIDS_IN_BLOCK;
+	lastblock = endl / IB_MLIDS_IN_BLOCK;
 	for (block = startblock; block <= lastblock; block++) {
 		for (j = 0; j < chunks; j++) {
 			int status;
@@ -207,10 +207,10 @@ static void dump_multicast_tables(ibnd_node_t *node, unsigned startlid,
 
 		i = block * IB_MLIDS_IN_BLOCK;
 		e = i + IB_MLIDS_IN_BLOCK;
-		if (i < startlid)
-			i = startlid;
-		if (e > endlid + 1)
-			e = endlid + 1;
+		if (i < startl)
+			i = startl;
+		if (e > endl + 1)
+			e = endl + 1;
 
 		for (; i < e; i++) {
 			if (dump_mlid(str, sizeof str, i, nports, mft) == 0)
@@ -301,7 +301,7 @@ static int dump_lid(char *str, int str_len, int lid, int valid,
 	return rc;
 }
 
-static void dump_unicast_tables(ibnd_node_t *node, int startlid, int endlid,
+static void dump_unicast_tables(ibnd_node_t *node, int startl, int endl,
 				struct ibmad_port *mad_port,
 				ibnd_fabric_t *fabric)
 {
@@ -322,27 +322,27 @@ static void dump_unicast_tables(ibnd_node_t *node, int startlid, int endlid,
 	nports = node->numports;
 	memcpy(nd, node->nodedesc, strlen(node->nodedesc));
 
-	if (!endlid || endlid > top)
-		endlid = top;
+	if (!endl || endl > top)
+		endl = top;
 
-	if (endlid > IB_MAX_UCAST_LID) {
-		IBWARN("illegal lft top %d, truncate to %d", endlid,
+	if (endl > IB_MAX_UCAST_LID) {
+		IBWARN("illegal lft top %d, truncate to %d", endl,
 		       IB_MAX_UCAST_LID);
-		endlid = IB_MAX_UCAST_LID;
+		endl = IB_MAX_UCAST_LID;
 	}
 
 	mapnd = remap_node_name(node_name_map, nodeguid, nd);
 
 	printf("Unicast lids [0x%x-0x%x] of switch %s guid 0x%016" PRIx64
-	       " (%s):\n", startlid, endlid, portid2str(portid), nodeguid,
+	       " (%s):\n", startl, endl, portid2str(portid), nodeguid,
 	       mapnd);
 
 	DEBUG("Switch top is 0x%x\n", top);
 
 	printf("  Lid  Out   Destination\n");
 	printf("       Port     Info \n");
-	startblock = startlid / IB_SMP_DATA_SIZE;
-	endblock = ALIGN(endlid, IB_SMP_DATA_SIZE) / IB_SMP_DATA_SIZE;
+	startblock = startl / IB_SMP_DATA_SIZE;
+	endblock = ALIGN(endl, IB_SMP_DATA_SIZE) / IB_SMP_DATA_SIZE;
 	for (block = startblock; block < endblock; block++) {
 		int status;
 		DEBUG("reading block %d", block);
@@ -357,10 +357,10 @@ static void dump_unicast_tables(ibnd_node_t *node, int startlid, int endlid,
 		}
 		i = block * IB_SMP_DATA_SIZE;
 		e = i + IB_SMP_DATA_SIZE;
-		if (i < startlid)
-			i = startlid;
-		if (e > endlid + 1)
-			e = endlid + 1;
+		if (i < startl)
+			i = startl;
+		if (e > endl + 1)
+			e = endl + 1;
 
 		for (; i < e; i++) {
 			unsigned outport = lft[i % IB_SMP_DATA_SIZE];

--- a/src/ibcacheedit.c
+++ b/src/ibcacheedit.c
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
 		 "Specify before and after port guid to edit"},
 		{0}
 	};
-	char *usage_args = "<orig.cache> <new.cache>";
+	const char *usage_args = "<orig.cache> <new.cache>";
 
 	ibdiag_process_opts(argc, argv, NULL, "CDdeGKLPstvy",
 			    opts, process_opt, usage_args,

--- a/src/ibccconfig.c
+++ b/src/ibccconfig.c
@@ -81,7 +81,7 @@ static const match_rec_t match_tbl[] = {
 uint64_t cckey = 0;
 
 /*******************************************/
-static char *parselonglongint(char *arg, uint64_t *val)
+static const char *parselonglongint(char *arg, uint64_t *val)
 {
 	char *endptr = NULL;
 
@@ -97,7 +97,7 @@ static char *parselonglongint(char *arg, uint64_t *val)
 	return NULL;
 }
 
-static char *parseint(char *arg, uint32_t *val, int hexonly)
+static const char *parseint(char *arg, uint32_t *val, int hexonly)
 {
 	char *endptr = NULL;
 
@@ -113,7 +113,7 @@ static char *parseint(char *arg, uint32_t *val, int hexonly)
 	return NULL;
 }
 
-static char *congestion_key_info(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_key_info(ib_portid_t *dest, char **argv, int argc)
 {
 	uint8_t rcv[IB_CC_DATA_SZ] = { 0 };
 	uint8_t payload[IB_CC_DATA_SZ] = { 0 };
@@ -121,7 +121,7 @@ static char *congestion_key_info(ib_portid_t * dest, char **argv, int argc)
 	uint32_t cc_keyprotectbit;
 	uint32_t cc_keyleaseperiod;
 	uint32_t cc_keyviolations;
-	char *errstr;
+	const char *errstr;
 
 	if (argc != 4)
 		return "invalid number of parameters for CongestionKeyInfo";
@@ -174,7 +174,7 @@ static char *congestion_key_info(ib_portid_t * dest, char **argv, int argc)
 
 
 /* parse like it's a hypothetical 256 bit hex code */
-static char *parse256(char *arg, uint8_t *buf)
+static const char *parse256(char *arg, uint8_t *buf)
 {
 	int numdigits = 0;
 	int startindex;
@@ -202,7 +202,7 @@ static char *parse256(char *arg, uint8_t *buf)
 	for (i = startindex; i <= 31; i++) {
 		char tmp[3] = { 0 };
 		uint32_t tmpint;
-		char *errstr;
+		const char *errstr;
 
 		/* I can't help but think there is a strtoX that
 		 * will do this for me, but I can't find it.
@@ -224,10 +224,10 @@ static char *parse256(char *arg, uint8_t *buf)
 	return NULL;
 }
 
-static char *parsecct(char *arg, uint32_t *shift, uint32_t *multiplier)
+static const char *parsecct(char *arg, uint32_t *shift, uint32_t *multiplier)
 {
 	char buf[1024] = { 0 };
-	char *errstr;
+	const char *errstr;
 	char *ptr;
 
 	strcpy(buf, arg);
@@ -247,7 +247,8 @@ static char *parsecct(char *arg, uint32_t *shift, uint32_t *multiplier)
 	return NULL;	
 }
 
-static char *switch_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *switch_congestion_setting(ib_portid_t *dest, char **argv,
+					     int argc)
 {
 	uint8_t rcv[IB_CC_DATA_SZ] = { 0 };
 	uint8_t payload[IB_CC_DATA_SZ] = { 0 };
@@ -261,7 +262,7 @@ static char *switch_congestion_setting(ib_portid_t * dest, char **argv, int argc
 	uint32_t cs_returndelay_m;
 	uint32_t cs_returndelay;
 	uint32_t marking_rate;
-	char *errstr;
+	const char *errstr;
 
 	if (argc != 8)
 		return "invalid number of parameters for SwitchCongestionSetting";
@@ -334,7 +335,8 @@ static char *switch_congestion_setting(ib_portid_t * dest, char **argv, int argc
 	return NULL;
 }
 
-static char *switch_port_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *switch_port_congestion_setting(ib_portid_t *dest,
+						  char **argv, int argc)
 {
 	uint8_t rcv[IB_CC_DATA_SZ] = { 0 };
 	uint8_t payload[IB_CC_DATA_SZ] = { 0 };
@@ -348,7 +350,7 @@ static char *switch_port_congestion_setting(ib_portid_t * dest, char **argv, int
 	uint32_t type;
 	uint32_t numports;
 	uint8_t *ptr;
-	char *errstr;
+	const char *errstr;
 
 	if (argc != 6)
 		return "invalid number of parameters for SwitchPortCongestion";
@@ -418,7 +420,8 @@ static char *switch_port_congestion_setting(ib_portid_t * dest, char **argv, int
 	return NULL;
 }
 
-static char *ca_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *ca_congestion_setting(ib_portid_t *dest, char **argv,
+					 int argc)
 {
 	uint8_t rcv[IB_CC_DATA_SZ] = { 0 };
 	uint8_t payload[IB_CC_DATA_SZ] = { 0 };
@@ -428,7 +431,7 @@ static char *ca_congestion_setting(ib_portid_t * dest, char **argv, int argc)
 	uint32_t ccti_increase;
 	uint32_t trigger_threshold;
 	uint32_t ccti_min;
-	char *errstr;
+	const char *errstr;
 	int i;
 
 	if (argc != 6)
@@ -492,7 +495,8 @@ static char *ca_congestion_setting(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *congestion_control_table(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_control_table(ib_portid_t *dest, char **argv,
+					    int argc)
 {
 	uint8_t rcv[IB_CC_DATA_SZ] = { 0 };
 	uint8_t payload[IB_CC_DATA_SZ] = { 0 };
@@ -500,7 +504,7 @@ static char *congestion_control_table(ib_portid_t * dest, char **argv, int argc)
 	uint32_t index;
 	uint32_t cctshifts[64];
 	uint32_t cctmults[64];
-	char *errstr;
+	const char *errstr;
 	int i;
 
 	if (argc < 2 || argc > 66)
@@ -558,7 +562,7 @@ int main(int argc, char **argv)
 	char usage_args[1024];
 	int mgmt_classes[3] = { IB_SMI_CLASS, IB_SA_CLASS, IB_CC_CLASS };
 	ib_portid_t portid = { 0 };
-	char *err;
+	const char *err;
 	op_fn_t *fn;
 	const match_rec_t *r;
 	int n;

--- a/src/ibccquery.c
+++ b/src/ibccquery.c
@@ -79,7 +79,7 @@ static const match_rec_t match_tbl[] = {
 uint64_t cckey = 0;
 
 /*******************************************/
-static char *class_port_info(ib_portid_t * dest, char **argv, int argc)
+static const char *class_port_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -94,7 +94,7 @@ static char *class_port_info(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *congestion_info(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -109,7 +109,7 @@ static char *congestion_info(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *congestion_key_info(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_key_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -124,7 +124,7 @@ static char *congestion_key_info(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *congestion_log(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_log(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_LOG_DATA_SZ] = { 0 };
@@ -180,7 +180,8 @@ static char *congestion_log(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *switch_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *switch_congestion_setting(ib_portid_t *dest, char **argv,
+					     int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -195,7 +196,8 @@ static char *switch_congestion_setting(ib_portid_t * dest, char **argv, int argc
 	return NULL;
 }
 
-static char *switch_port_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *switch_port_congestion_setting(ib_portid_t *dest,
+						  char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -257,7 +259,8 @@ static char *switch_port_congestion_setting(ib_portid_t * dest, char **argv, int
 	return NULL;
 }
 
-static char *ca_congestion_setting(ib_portid_t * dest, char **argv, int argc)
+static const char *ca_congestion_setting(ib_portid_t *dest, char **argv,
+					 int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -281,7 +284,8 @@ static char *ca_congestion_setting(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *congestion_control_table(ib_portid_t * dest, char **argv, int argc)
+static const char *congestion_control_table(ib_portid_t *dest, char **argv,
+					    int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -321,7 +325,7 @@ static char *congestion_control_table(ib_portid_t * dest, char **argv, int argc)
 	return NULL;
 }
 
-static char *timestamp_dump(ib_portid_t * dest, char **argv, int argc)
+static const char *timestamp_dump(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_CC_DATA_SZ] = { 0 };
@@ -353,7 +357,7 @@ int main(int argc, char **argv)
 	char usage_args[1024];
 	int mgmt_classes[3] = { IB_SMI_CLASS, IB_SA_CLASS, IB_CC_CLASS };
 	ib_portid_t portid = { 0 };
-	char *err;
+	const char *err;
 	op_fn_t *fn;
 	const match_rec_t *r;
 	int n;

--- a/src/ibdiag_common.c
+++ b/src/ibdiag_common.c
@@ -118,7 +118,7 @@ static inline int val_str_true(const char *val_str)
 		(strncmp(val_str, "true", strlen("true")) == 0));
 }
 
-void read_ibdiag_config(const char *file)
+static void read_ibdiag_config(const char *file)
 {
 	char buf[1024];
 	FILE *config_fd = NULL;
@@ -633,9 +633,9 @@ int resolve_self(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
 	return 0;
 }
 
-int resolve_gid(char *ca_name, uint8_t ca_port, ib_portid_t * portid,
-		ibmad_gid_t gid, ib_portid_t * sm_id,
-		const struct ibmad_port *srcport)
+static int resolve_gid(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
+		       ibmad_gid_t gid, ib_portid_t *sm_id,
+		       const struct ibmad_port *srcport)
 {
 	ib_portid_t sm_portid;
 	char buf[IB_SA_DATA_SIZE] = { 0 };
@@ -653,9 +653,9 @@ int resolve_gid(char *ca_name, uint8_t ca_port, ib_portid_t * portid,
 	return 0;
 }
 
-int resolve_guid(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
-		 uint64_t *guid, ib_portid_t *sm_id,
-		 const struct ibmad_port *srcport)
+static int resolve_guid(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
+			uint64_t *guid, ib_portid_t *sm_id,
+			const struct ibmad_port *srcport)
 {
 	ib_portid_t sm_portid;
 	uint8_t buf[IB_SA_DATA_SIZE] = { 0 };

--- a/src/ibdiag_common.c
+++ b/src/ibdiag_common.c
@@ -413,7 +413,7 @@ int ibdiag_process_opts(int argc, char *const argv[], void *cxt,
 	return 0;
 }
 
-void ibexit(const char *fn, char *msg, ...)
+void ibexit(const char *fn, const char *msg, ...)
 {
 	char buf[512];
 	va_list va;
@@ -434,8 +434,7 @@ void ibexit(const char *fn, char *msg, ...)
 	exit(-1);
 }
 
-char *
-conv_cnt_human_readable(uint64_t val64, float *val, int data)
+const char *conv_cnt_human_readable(uint64_t val64, float *val, int data)
 {
 	uint64_t tmp = val64;
 	int ui = 0;

--- a/src/ibdiag_common.c
+++ b/src/ibdiag_common.c
@@ -174,7 +174,7 @@ static void read_ibdiag_config(const char *file)
 }
 
 
-void ibdiag_show_usage()
+void ibdiag_show_usage(void)
 {
 	struct option *o = long_opts;
 	int n;

--- a/src/ibdiag_common.c
+++ b/src/ibdiag_common.c
@@ -328,7 +328,7 @@ static struct option *make_long_opts(const char *exclude_str,
 				     const struct ibdiag_opt *custom_opts,
 				     const struct ibdiag_opt *map[])
 {
-	struct option *long_opts, *l;
+	struct option *res, *l;
 	const struct ibdiag_opt *o;
 	unsigned n = 0;
 
@@ -336,12 +336,12 @@ static struct option *make_long_opts(const char *exclude_str,
 		for (o = custom_opts; o->name; o++)
 			n++;
 
-	long_opts = malloc((sizeof(common_opts) / sizeof(common_opts[0]) + n) *
-			   sizeof(*long_opts));
-	if (!long_opts)
+	res = malloc((sizeof(common_opts) / sizeof(common_opts[0]) + n) *
+		     sizeof(*res));
+	if (!res)
 		return NULL;
 
-	l = long_opts;
+	l = res;
 
 	if (custom_opts)
 		for (o = custom_opts; o->name; o++)
@@ -355,7 +355,7 @@ static struct option *make_long_opts(const char *exclude_str,
 
 	memset(l, 0, sizeof(*l));
 
-	return long_opts;
+	return res;
 }
 
 static void make_str_opts(const struct option *o, char *p, unsigned size)
@@ -637,11 +637,11 @@ static int resolve_gid(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
 		       ibmad_gid_t gid, ib_portid_t *sm_id,
 		       const struct ibmad_port *srcport)
 {
-	ib_portid_t sm_portid;
+	ib_portid_t tmp;
 	char buf[IB_SA_DATA_SIZE] = { 0 };
 
 	if (!sm_id) {
-		sm_id = &sm_portid;
+		sm_id = &tmp;
 		if (resolve_sm_portid(ca_name, ca_port, sm_id) < 0)
 			return -1;
 	}
@@ -657,13 +657,13 @@ static int resolve_guid(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
 			uint64_t *guid, ib_portid_t *sm_id,
 			const struct ibmad_port *srcport)
 {
-	ib_portid_t sm_portid;
+	ib_portid_t tmp;
 	uint8_t buf[IB_SA_DATA_SIZE] = { 0 };
 	uint64_t prefix;
 	ibmad_gid_t selfgid;
 
 	if (!sm_id) {
-		sm_id = &sm_portid;
+		sm_id = &tmp;
 		if (resolve_sm_portid(ca_name, ca_port, sm_id) < 0)
 			return -1;
 	}

--- a/src/iblinkinfo.c
+++ b/src/iblinkinfo.c
@@ -104,7 +104,7 @@ int filterdownport_check(ibnd_node_t * node, ibnd_port_t * port)
 	return (fistate == IB_LINK_DOWN) ? 1 : 0;
 }
 
-void print_port(ibnd_node_t * node, ibnd_port_t * port, char *out_prefix)
+void print_port(ibnd_node_t *node, ibnd_port_t *port, const char *out_prefix)
 {
 	char width[64], speed[64], state[64], physstate[64];
 	char remote_guid_str[256];
@@ -272,7 +272,7 @@ static inline const char *nodetype_str(ibnd_node_t * node)
 }
 
 void print_node_header(ibnd_node_t *node, int *out_header_flag,
-			char *out_prefix)
+		       const char *out_prefix)
 {
 	uint64_t guid = 0;
 	if ((!out_header_flag || !(*out_header_flag)) && !line_mode) {
@@ -321,8 +321,8 @@ struct iter_diff_data {
         uint32_t diff_flags;
         ibnd_fabric_t *fabric1;
         ibnd_fabric_t *fabric2;
-        char *fabric1_prefix;
-        char *fabric2_prefix;
+        const char *fabric1_prefix;
+        const char *fabric2_prefix;
 };
 
 void diff_node_ports(ibnd_node_t * fabric1_node, ibnd_node_t * fabric2_node,
@@ -417,7 +417,7 @@ void diff_node_iter(ibnd_node_t * fabric1_node, void *iter_user_data)
 
 	fabric2_node = ibnd_find_node_guid(data->fabric2, fabric1_node->guid);
 	if (!fabric2_node)
-		print_node(fabric1_node, data->fabric1_prefix);
+		print_node(fabric1_node, (void *)data->fabric1_prefix);
 	else if (data->diff_flags &
 		 (DIFF_FLAG_PORT_CONNECTION | DIFF_FLAG_PORT_STATE
 		  | DIFF_FLAG_LID | DIFF_FLAG_NODE_DESCRIPTION)) {

--- a/src/iblinkinfo.c
+++ b/src/iblinkinfo.c
@@ -80,7 +80,7 @@ static int add_sw_settings = 0;
 static int only_flag = 0;
 static int only_type = 0;
 
-int filterdownport_check(ibnd_node_t * node, ibnd_port_t * port)
+static int filterdownport_check(ibnd_node_t *node, ibnd_port_t *port)
 {
 	ibnd_node_t *fsw;
 	ibnd_port_t *fport;
@@ -104,7 +104,8 @@ int filterdownport_check(ibnd_node_t * node, ibnd_port_t * port)
 	return (fistate == IB_LINK_DOWN) ? 1 : 0;
 }
 
-void print_port(ibnd_node_t *node, ibnd_port_t *port, const char *out_prefix)
+static void print_port(ibnd_node_t *node, ibnd_port_t *port,
+		       const char *out_prefix)
 {
 	char width[64], speed[64], state[64], physstate[64];
 	char remote_guid_str[256];
@@ -271,7 +272,7 @@ static inline const char *nodetype_str(ibnd_node_t * node)
 	return "??";
 }
 
-void print_node_header(ibnd_node_t *node, int *out_header_flag,
+static void print_node_header(ibnd_node_t *node, int *out_header_flag,
 		       const char *out_prefix)
 {
 	uint64_t guid = 0;
@@ -298,7 +299,7 @@ void print_node_header(ibnd_node_t *node, int *out_header_flag,
 	}
 }
 
-void print_node(ibnd_node_t * node, void *user_data)
+static void print_node(ibnd_node_t *node, void *user_data)
 {
 	int i = 0;
 	int head_print = 0;
@@ -325,8 +326,9 @@ struct iter_diff_data {
         const char *fabric2_prefix;
 };
 
-void diff_node_ports(ibnd_node_t * fabric1_node, ibnd_node_t * fabric2_node,
-		       int *head_print, struct iter_diff_data *data)
+static void diff_node_ports(ibnd_node_t *fabric1_node,
+			    ibnd_node_t *fabric2_node, int *head_print,
+			    struct iter_diff_data *data)
 {
 	int i = 0;
 
@@ -407,7 +409,7 @@ void diff_node_ports(ibnd_node_t * fabric1_node, ibnd_node_t * fabric2_node,
 	}
 }
 
-void diff_node_iter(ibnd_node_t * fabric1_node, void *iter_user_data)
+static void diff_node_iter(ibnd_node_t *fabric1_node, void *iter_user_data)
 {
 	struct iter_diff_data *data = iter_user_data;
 	ibnd_node_t *fabric2_node;
@@ -453,8 +455,8 @@ void diff_node_iter(ibnd_node_t * fabric1_node, void *iter_user_data)
 	}
 }
 
-int diff_node(ibnd_node_t * node, ibnd_fabric_t * orig_fabric,
-		ibnd_fabric_t * new_fabric)
+static int diff_node(ibnd_node_t *node, ibnd_fabric_t *orig_fabric,
+		     ibnd_fabric_t *new_fabric)
 {
 	struct iter_diff_data iter_diff_data;
 

--- a/src/ibnetdiscover.c
+++ b/src/ibnetdiscover.c
@@ -84,7 +84,7 @@ static int full_info;
  * Define our own conversion functions to maintain compatibility with the old
  * ibnetdiscover which did not use the ibmad conversion functions.
  */
-char *dump_linkspeed_compat(uint32_t speed)
+const char *dump_linkspeed_compat(uint32_t speed)
 {
 	switch (speed) {
 	case 1:
@@ -100,7 +100,8 @@ char *dump_linkspeed_compat(uint32_t speed)
 	return ("???");
 }
 
-char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed, uint32_t fdr10)
+const char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed,
+				     uint32_t fdr10)
 {
 	switch (espeed) {
 	case 0:
@@ -122,7 +123,7 @@ char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed, uint32_t fdr10)
 	return ("???");
 }
 
-char *dump_linkwidth_compat(uint32_t width)
+const char *dump_linkwidth_compat(uint32_t width)
 {
 	switch (width) {
 	case 1:
@@ -220,7 +221,7 @@ void list_nodes(ibnd_fabric_t * fabric, int list)
 		ibnd_iter_nodes_type(fabric, list_node, IB_NODE_ROUTER, NULL);
 }
 
-void out_ids(ibnd_node_t * node, int group, char *chname, char *out_prefix)
+void out_ids(ibnd_node_t *node, int group, char *chname, const char *out_prefix)
 {
 	uint64_t sysimgguid =
 	    mad_get_field64(node->info, 0, IB_NODE_SYSTEM_GUID_F);
@@ -258,7 +259,7 @@ uint64_t out_chassis(ibnd_fabric_t * fabric, unsigned char chassisnum)
 	return guid;
 }
 
-void out_switch_detail(ibnd_node_t * node, char *sw_prefix)
+void out_switch_detail(ibnd_node_t * node, const char *sw_prefix)
 {
 	char *nodename = NULL;
 
@@ -272,10 +273,10 @@ void out_switch_detail(ibnd_node_t * node, char *sw_prefix)
 	free(nodename);
 }
 
-void out_switch(ibnd_node_t * node, int group, char *chname, char *id_prefix,
-		char *sw_prefix)
+void out_switch(ibnd_node_t *node, int group, char *chname,
+		const char *id_prefix, const char *sw_prefix)
 {
-	char *str;
+	const char *str;
 	char str2[256];
 
 	out_ids(node, group, chname, id_prefix);
@@ -298,9 +299,9 @@ void out_switch(ibnd_node_t * node, int group, char *chname, char *id_prefix,
 	fprintf(f, "\n");
 }
 
-void out_ca_detail(ibnd_node_t * node, char *ca_prefix)
+void out_ca_detail(ibnd_node_t *node, const char *ca_prefix)
 {
-	char *node_type;
+	const char *node_type;
 
 	switch (node->type) {
 	case IB_NODE_CA:
@@ -319,10 +320,10 @@ void out_ca_detail(ibnd_node_t * node, char *ca_prefix)
 		clean_nodedesc(node->nodedesc));
 }
 
-void out_ca(ibnd_node_t * node, int group, char *chname, char *id_prefix,
-	    char *ca_prefix)
+void out_ca(ibnd_node_t *node, int group, char *chname, const char *id_prefix,
+	    const char *ca_prefix)
 {
-	char *node_type;
+	const char *node_type;
 
 	out_ids(node, group, chname, id_prefix);
 	switch (node->type) {
@@ -359,7 +360,8 @@ static char *out_ext_port(ibnd_port_t * port, int group)
 	return (NULL);
 }
 
-void out_switch_port(ibnd_port_t * port, int group, char *out_prefix)
+static void out_switch_port(ibnd_port_t *port, int group,
+			    const char *out_prefix)
 {
 	char *ext_port_str = NULL;
 	char *rem_nodename = NULL;
@@ -427,7 +429,7 @@ void out_switch_port(ibnd_port_t * port, int group, char *out_prefix)
 	free(rem_nodename);
 }
 
-void out_ca_port(ibnd_port_t * port, int group, char *out_prefix)
+void out_ca_port(ibnd_port_t *port, int group, const char *out_prefix)
 {
 	char *str = NULL;
 	char *rem_nodename = NULL;
@@ -760,11 +762,12 @@ struct iter_diff_data {
 	uint32_t diff_flags;
 	ibnd_fabric_t *fabric1;
 	ibnd_fabric_t *fabric2;
-	char *fabric1_prefix;
-	char *fabric2_prefix;
-	void (*out_header) (ibnd_node_t *, int, char *, char *, char *);
-	void (*out_header_detail) (ibnd_node_t *, char *);
-	void (*out_port) (ibnd_port_t *, int, char *);
+	const char *fabric1_prefix;
+	const char *fabric2_prefix;
+	void (*out_header)(ibnd_node_t *, int, char *, const char *,
+			   const char *);
+	void (*out_header_detail)(ibnd_node_t *, const char *);
+	void (*out_port)(ibnd_port_t *, int, const char *);
 };
 
 static void diff_iter_out_header(ibnd_node_t * node,
@@ -921,12 +924,12 @@ static void diff_iter_func(ibnd_node_t * fabric1_node, void *iter_user_data)
 	}
 }
 
-static int diff_common(ibnd_fabric_t * orig_fabric, ibnd_fabric_t * new_fabric,
+static int diff_common(ibnd_fabric_t *orig_fabric, ibnd_fabric_t *new_fabric,
 		       int node_type, uint32_t diff_flags,
-		       void (*out_header) (ibnd_node_t *, int, char *, char *,
-					   char *),
-		       void (*out_header_detail) (ibnd_node_t *, char *),
-		       void (*out_port) (ibnd_port_t *, int, char *))
+		       void (*out_header)(ibnd_node_t *, int, char *,
+					  const char *, const char *),
+		       void (*out_header_detail)(ibnd_node_t *, const char *),
+		       void (*out_port)(ibnd_port_t *, int, const char *))
 {
 	struct iter_diff_data iter_diff_data;
 

--- a/src/ibnetdiscover.c
+++ b/src/ibnetdiscover.c
@@ -84,7 +84,7 @@ static int full_info;
  * Define our own conversion functions to maintain compatibility with the old
  * ibnetdiscover which did not use the ibmad conversion functions.
  */
-const char *dump_linkspeed_compat(uint32_t speed)
+static const char *dump_linkspeed_compat(uint32_t speed)
 {
 	switch (speed) {
 	case 1:
@@ -100,8 +100,8 @@ const char *dump_linkspeed_compat(uint32_t speed)
 	return ("???");
 }
 
-const char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed,
-				     uint32_t fdr10)
+static const char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed,
+					    uint32_t fdr10)
 {
 	switch (espeed) {
 	case 0:
@@ -123,7 +123,7 @@ const char *dump_linkspeedext_compat(uint32_t espeed, uint32_t speed,
 	return ("???");
 }
 
-const char *dump_linkwidth_compat(uint32_t width)
+static const char *dump_linkwidth_compat(uint32_t width)
 {
 	switch (width) {
 	case 1:
@@ -158,7 +158,7 @@ static inline const char *ports_nt_str_compat(ibnd_node_t * node)
 	return "??";
 }
 
-char *node_name(ibnd_node_t * node)
+static char *node_name(ibnd_node_t * node)
 {
 	static char buf[256];
 
@@ -181,9 +181,9 @@ char *node_name(ibnd_node_t * node)
 	return buf;
 }
 
-void list_node(ibnd_node_t * node, void *user_data)
+static void list_node(ibnd_node_t *node, void *user_data)
 {
-	char *node_type;
+	const char *node_type;
 	char *nodename = remap_node_name(node_name_map, node->guid,
 					 node->nodedesc);
 
@@ -211,7 +211,7 @@ void list_node(ibnd_node_t * node, void *user_data)
 	free(nodename);
 }
 
-void list_nodes(ibnd_fabric_t * fabric, int list)
+static void list_nodes(ibnd_fabric_t *fabric, int list)
 {
 	if (list & LIST_CA_NODE)
 		ibnd_iter_nodes_type(fabric, list_node, IB_NODE_CA, NULL);
@@ -221,7 +221,8 @@ void list_nodes(ibnd_fabric_t * fabric, int list)
 		ibnd_iter_nodes_type(fabric, list_node, IB_NODE_ROUTER, NULL);
 }
 
-void out_ids(ibnd_node_t *node, int group, char *chname, const char *out_prefix)
+static void out_ids(ibnd_node_t *node, int group, char *chname,
+		    const char *out_prefix)
 {
 	uint64_t sysimgguid =
 	    mad_get_field64(node->info, 0, IB_NODE_SYSTEM_GUID_F);
@@ -247,7 +248,7 @@ void out_ids(ibnd_node_t *node, int group, char *chname, const char *out_prefix)
 		fprintf(f, "\n");
 }
 
-uint64_t out_chassis(ibnd_fabric_t * fabric, unsigned char chassisnum)
+static uint64_t out_chassis(ibnd_fabric_t *fabric, unsigned char chassisnum)
 {
 	uint64_t guid;
 
@@ -259,7 +260,7 @@ uint64_t out_chassis(ibnd_fabric_t * fabric, unsigned char chassisnum)
 	return guid;
 }
 
-void out_switch_detail(ibnd_node_t * node, const char *sw_prefix)
+static void out_switch_detail(ibnd_node_t *node, const char *sw_prefix)
 {
 	char *nodename = NULL;
 
@@ -273,8 +274,8 @@ void out_switch_detail(ibnd_node_t * node, const char *sw_prefix)
 	free(nodename);
 }
 
-void out_switch(ibnd_node_t *node, int group, char *chname,
-		const char *id_prefix, const char *sw_prefix)
+static void out_switch(ibnd_node_t *node, int group, char *chname,
+		       const char *id_prefix, const char *sw_prefix)
 {
 	const char *str;
 	char str2[256];
@@ -299,7 +300,7 @@ void out_switch(ibnd_node_t *node, int group, char *chname,
 	fprintf(f, "\n");
 }
 
-void out_ca_detail(ibnd_node_t *node, const char *ca_prefix)
+static void out_ca_detail(ibnd_node_t *node, const char *ca_prefix)
 {
 	const char *node_type;
 
@@ -320,8 +321,8 @@ void out_ca_detail(ibnd_node_t *node, const char *ca_prefix)
 		clean_nodedesc(node->nodedesc));
 }
 
-void out_ca(ibnd_node_t *node, int group, char *chname, const char *id_prefix,
-	    const char *ca_prefix)
+static void out_ca(ibnd_node_t *node, int group, char *chname,
+		   const char *id_prefix, const char *ca_prefix)
 {
 	const char *node_type;
 
@@ -429,7 +430,7 @@ static void out_switch_port(ibnd_port_t *port, int group,
 	free(rem_nodename);
 }
 
-void out_ca_port(ibnd_port_t *port, int group, const char *out_prefix)
+static void out_ca_port(ibnd_port_t *port, int group, const char *out_prefix)
 {
 	char *str = NULL;
 	char *rem_nodename = NULL;
@@ -545,7 +546,7 @@ static void router_iter_func(ibnd_node_t * node, void *iter_user_data)
 	}
 }
 
-int dump_topology(int group, ibnd_fabric_t * fabric)
+static int dump_topology(int group, ibnd_fabric_t *fabric)
 {
 	ibnd_node_t *node;
 	ibnd_port_t *port;
@@ -687,7 +688,7 @@ int dump_topology(int group, ibnd_fabric_t * fabric)
 	return i;
 }
 
-void dump_ports_report(ibnd_node_t * node, void *user_data)
+static void dump_ports_report(ibnd_node_t *node, void *user_data)
 {
 	int p = 0;
 	ibnd_port_t *port = NULL;
@@ -968,7 +969,7 @@ static int diff_common(ibnd_fabric_t *orig_fabric, ibnd_fabric_t *new_fabric,
 	return 0;
 }
 
-int diff(ibnd_fabric_t * orig_fabric, ibnd_fabric_t * new_fabric)
+static int diff(ibnd_fabric_t *orig_fabric, ibnd_fabric_t *new_fabric)
 {
 	if (diffcheck_flags & DIFF_FLAG_SWITCH)
 		diff_common(orig_fabric, new_fabric, IB_NODE_SWITCH,

--- a/src/ibping.c
+++ b/src/ibping.c
@@ -142,7 +142,7 @@ static uint64_t minrtt = ~0ull, maxrtt, total_rtt;
 static uint64_t start, total_time, replied, lost, ntrans;
 static ib_portid_t portid = { 0 };
 
-void report(int sig)
+static void report(int sig)
 {
 	total_time = cl_get_time_stamp() - start;
 

--- a/src/ibportstate.c
+++ b/src/ibportstate.c
@@ -304,7 +304,7 @@ static int get_link_speed_ext(int lsee, int lses)
 		return lsee;
 }
 
-static void validate_width(int width, int peerwidth, int lwa)
+static void validate_width(int peerwidth, int lwa)
 {
 	if ((width & peerwidth & 0x8)) {
 		if (lwa != 8)
@@ -334,7 +334,7 @@ static void validate_width(int width, int peerwidth, int lwa)
 	}
 }
 
-static void validate_speed(int speed, int peerspeed, int lsa)
+static void validate_speed(int peerspeed, int lsa)
 {
 	if ((speed & peerspeed & 0x4)) {
 		if (lsa != 4)
@@ -354,7 +354,7 @@ static void validate_speed(int speed, int peerspeed, int lsa)
 	}
 }
 
-static void validate_extended_speed(int espeed, int peerespeed, int lsea)
+static void validate_extended_speed(int peerespeed, int lsea)
 {
 	if ((espeed & peerespeed & 0x4)) {
 		if (lsea != 4)
@@ -744,19 +744,18 @@ int main(int argc, char **argv)
 			/* Examine Link Width */
 			width = get_link_width(lwe, lws);
 			peerwidth = get_link_width(peerlwe, peerlws);
-			validate_width(width, peerwidth, lwa);
+			validate_width(peerwidth, lwa);
 
 			/* Examine Link Speeds */
 			speed = get_link_speed(lse, lss);
 			peerspeed = get_link_speed(peerlse, peerlss);
-			validate_speed(speed, peerspeed, lsa);
+			validate_speed(peerspeed, lsa);
 
 			if (espeed_cap && peer_espeed_cap) {
 				espeed = get_link_speed_ext(lsee, lses);
 				peerespeed = get_link_speed_ext(peerlsee,
 								peerlses);
-				validate_extended_speed(espeed, peerespeed,
-							lsea);
+				validate_extended_speed(peerespeed, lsea);
 			} else {
 				if (fdr10e & FDR10 && peerfdr10e & FDR10) {
 					if (!(fdr10a & FDR10))

--- a/src/ibqueryerrors.c
+++ b/src/ibqueryerrors.c
@@ -127,7 +127,7 @@ static void set_thres(char *name, uint64_t val)
 	}
 }
 
-static void set_thresholds(const char *threshold_file)
+static void set_thresholds(void)
 {
 	char buf[1024];
 	uint64_t val = 0;
@@ -1104,7 +1104,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	set_thresholds(threshold_file);
+	set_thresholds();
 
 	/* reopen the global ibmad_port */
 	ibmad_port = mad_rpc_open_port(ibd_ca, ibd_ca_port,

--- a/src/ibqueryerrors.c
+++ b/src/ibqueryerrors.c
@@ -673,9 +673,9 @@ static int print_errors(ib_portid_t * portid, uint16_t cap_mask, uint32_t cap_ma
 			      header_printed, pc_ext, cap_mask, cap_mask2));
 }
 
-uint8_t *reset_pc_ext(void *rcvbuf, ib_portid_t * dest,
-		      int port, unsigned mask, unsigned timeout,
-		      const struct ibmad_port * srcport)
+static uint8_t *reset_pc_ext(void *rcvbuf, ib_portid_t *dest, int port,
+			     unsigned mask, unsigned timeout,
+			     const struct ibmad_port *srcport)
 {
 	ib_rpc_t rpc = { 0 };
 	int lid = dest->lid;
@@ -770,7 +770,7 @@ static void clear_port(ib_portid_t * portid, uint16_t cap_mask, uint32_t cap_mas
 	}
 }
 
-void print_node(ibnd_node_t * node, void *user_data)
+static void print_node(ibnd_node_t *node, void *user_data)
 {
 	int header_printed = 0;
 	int p = 0;

--- a/src/ibqueryerrors.c
+++ b/src/ibqueryerrors.c
@@ -1122,14 +1122,15 @@ int main(int argc, char **argv)
 		mad_rpc_set_timeout(ibmad_port, ibd_timeout);
 
 	if (port_guid_str) {
-		ibnd_port_t *port = ibnd_find_port_guid(fabric, port_guid);
-		if (port)
-			print_node(port->node, NULL);
+		ibnd_port_t *ndport = ibnd_find_port_guid(fabric, port_guid);
+		if (ndport)
+			print_node(ndport->node, NULL);
 		else
 			fprintf(stderr, "Failed to find node: %s\n",
 				port_guid_str);
 	} else if (dr_path) {
-		ibnd_port_t *port;
+		ibnd_port_t *ndport;
+
 		uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 		if (!smp_query_via(ni, &portid, IB_ATTR_NODE_INFO, 0,
 			   ibd_timeout, ibmad_port)) {
@@ -1139,12 +1140,12 @@ int main(int argc, char **argv)
 
 		mad_decode_field(ni, IB_NODE_PORT_GUID_F, &(port_guid));
 
-		port = ibnd_find_port_guid(fabric, port_guid);
-		if (port) {
+		ndport = ibnd_find_port_guid(fabric, port_guid);
+		if (ndport) {
 			if(obtain_sl)
-				if(path_record_query(self_gid,port->guid))
+				if(path_record_query(self_gid,ndport->guid))
 					goto close_port;
-			print_node(port->node, NULL);
+			print_node(ndport->node, NULL);
 		} else
 			fprintf(stderr, "Failed to find node: %s\n", dr_path);
 	} else {

--- a/src/ibqueryerrors.c
+++ b/src/ibqueryerrors.c
@@ -92,11 +92,11 @@ struct {
 } summary = { 0 };
 
 #define DEF_THRES_FILE IBDIAG_CONFIG_PATH"/error_thresholds"
-static char *threshold_file = DEF_THRES_FILE;
+static const char *threshold_file = DEF_THRES_FILE;
 
 /* define a "packet" with threshold values in it */
 uint8_t thresholds[1204] = { 0 };
-char * threshold_str = "";
+char *threshold_str = NULL;
 
 static unsigned valid_gid(ib_gid_t * gid)
 {
@@ -127,7 +127,7 @@ static void set_thres(char *name, uint64_t val)
 	}
 }
 
-static void set_thresholds(char *threshold_file)
+static void set_thresholds(const char *threshold_file)
 {
 	char buf[1024];
 	uint64_t val = 0;
@@ -399,7 +399,7 @@ static int check_threshold(uint8_t *pc, uint8_t *pce, uint32_t cap_mask2,
 	uint64_t val64 = 0;
 	int is_exceeds = 0;
 	float val = 0;
-	char *unit = "";
+	const char *unit = "";
 
 	if (htonl(cap_mask2) & IB_PM_IS_ADDL_PORT_CTRS_EXT_SUP) {
 		mad_decode_field(pce, ext_i, (void *)&val64);
@@ -488,7 +488,7 @@ static int print_results(ib_portid_t * portid, char *node_name,
 			for (i = start_field; i <= end_field; i++) {
 				uint64_t val64 = 0;
 				float val = 0;
-				char *unit = "";
+				const char *unit = "";
 				mad_decode_field(pkt, i, (void *)&val64);
 				if (val64) {
 					int data = 0;
@@ -614,7 +614,7 @@ static int print_data_cnts(ib_portid_t * portid, uint16_t cap_mask,
 	for (i = start_field; i <= end_field; i++) {
 		uint64_t val64 = 0;
 		float val = 0;
-		char *unit = "";
+		const char *unit = "";
 		int data = 0;
 		mad_decode_field(pc, i, (void *)&val64);
 		if (i == IB_PC_EXT_XMT_BYTES_F || i == IB_PC_EXT_RCV_BYTES_F ||

--- a/src/ibroute.c
+++ b/src/ibroute.c
@@ -59,8 +59,8 @@ static nn_map_t *node_name_map = NULL;
 
 /*******************************************/
 
-const char *check_switch(ib_portid_t *portid, unsigned int *nports,
-			 uint64_t *guid, uint8_t *sw, char *nd)
+static const char *check_switch(ib_portid_t *portid, unsigned int *nports,
+				uint64_t *guid, uint8_t *sw, char *nd)
 {
 	uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 	int type;
@@ -90,8 +90,8 @@ const char *check_switch(ib_portid_t *portid, unsigned int *nports,
 
 #define IB_MLIDS_IN_BLOCK	(IB_SMP_DATA_SIZE/2)
 
-int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
-	      uint16_t mft[16][IB_MLIDS_IN_BLOCK])
+static int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
+		     uint16_t mft[16][IB_MLIDS_IN_BLOCK])
 {
 	uint16_t mask;
 	unsigned i, chunk, bit, nonzero = 0;
@@ -135,8 +135,8 @@ int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
 
 uint16_t mft[16][IB_MLIDS_IN_BLOCK] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0}, { 0 }, { 0 } };
 
-const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
-				  unsigned endlid)
+static const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
+					 unsigned endlid)
 {
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
 	uint8_t sw[IB_SMP_DATA_SIZE] = { 0 };
@@ -247,7 +247,7 @@ const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
 	return 0;
 }
 
-int dump_lid(char *str, int strlen, int lid, int valid)
+static int dump_lid(char *str, int strlen, int lid, int valid)
 {
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
 	uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
@@ -322,7 +322,8 @@ int dump_lid(char *str, int strlen, int lid, int valid)
 	return rc;
 }
 
-const char *dump_unicast_tables(ib_portid_t *portid, int startlid, int endlid)
+static const char *dump_unicast_tables(ib_portid_t *portid, int startlid,
+				       int endlid)
 {
 	char lft[IB_SMP_DATA_SIZE] = { 0 };
 	char nd[IB_SMP_DATA_SIZE] = { 0 };

--- a/src/ibroute.c
+++ b/src/ibroute.c
@@ -59,8 +59,8 @@ static nn_map_t *node_name_map = NULL;
 
 /*******************************************/
 
-char *check_switch(ib_portid_t * portid, unsigned int *nports, uint64_t * guid,
-		   uint8_t * sw, char *nd)
+const char *check_switch(ib_portid_t *portid, unsigned int *nports,
+			 uint64_t *guid, uint8_t *sw, char *nd)
 {
 	uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 	int type;
@@ -135,13 +135,13 @@ int dump_mlid(char *str, int strlen, unsigned mlid, unsigned nports,
 
 uint16_t mft[16][IB_MLIDS_IN_BLOCK] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0}, { 0 }, { 0 } };
 
-char *dump_multicast_tables(ib_portid_t * portid, unsigned startlid,
-			    unsigned endlid)
+const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
+				  unsigned endlid)
 {
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
 	uint8_t sw[IB_SMP_DATA_SIZE] = { 0 };
-	char str[512];
-	char *s;
+	char str[512], *s;
+	const char *err;
 	uint64_t nodeguid;
 	uint32_t mod;
 	unsigned block, i, j, e, nports, cap, chunks, startblock, lastblock,
@@ -149,8 +149,8 @@ char *dump_multicast_tables(ib_portid_t * portid, unsigned startlid,
 	char *mapnd = NULL;
 	int n = 0;
 
-	if ((s = check_switch(portid, &nports, &nodeguid, sw, nd)))
-		return s;
+	if ((err = check_switch(portid, &nports, &nodeguid, sw, nd)))
+		return err;
 
 	mad_decode_field(sw, IB_SW_MCAST_FDB_CAP_F, &cap);
 	mad_decode_field(sw, IB_SW_MCAST_FDB_TOP_F, &top);
@@ -322,12 +322,13 @@ int dump_lid(char *str, int strlen, int lid, int valid)
 	return rc;
 }
 
-char *dump_unicast_tables(ib_portid_t * portid, int startlid, int endlid)
+const char *dump_unicast_tables(ib_portid_t *portid, int startlid, int endlid)
 {
 	char lft[IB_SMP_DATA_SIZE] = { 0 };
 	char nd[IB_SMP_DATA_SIZE] = { 0 };
 	uint8_t sw[IB_SMP_DATA_SIZE] = { 0 };
-	char str[200], *s;
+	char str[200];
+	const char *s;
 	uint64_t nodeguid;
 	int block, i, e, top;
 	unsigned nports;
@@ -423,7 +424,7 @@ int main(int argc, char **argv)
 	    { IB_SMI_CLASS, IB_SMI_DIRECT_CLASS, IB_SA_CLASS };
 	ib_portid_t portid = { 0 };
 	unsigned startlid = 0, endlid = 0;
-	char *err;
+	const char *err;
 
 	const struct ibdiag_opt opts[] = {
 		{"all", 'a', 0, NULL, "show all lids, even invalid entries"},

--- a/src/ibsendtrap.c
+++ b/src/ibsendtrap.c
@@ -224,7 +224,7 @@ static const trap_def_t traps[] = {
 	{NULL, NULL}
 };
 
-int process_send_trap(const char *trap_name)
+static int process_send_trap(const char *trap_name)
 {
 	int i;
 

--- a/src/ibsendtrap.c
+++ b/src/ibsendtrap.c
@@ -208,7 +208,7 @@ static int send_trap(void (*build) (ib_mad_notice_attr_t *, ib_portid_t *))
 }
 
 typedef struct _trap_def {
-	char *trap_name;
+	const char *trap_name;
 	void (*build_func) (ib_mad_notice_attr_t *, ib_portid_t *);
 } trap_def_t;
 
@@ -224,7 +224,7 @@ static const trap_def_t traps[] = {
 	{NULL, NULL}
 };
 
-int process_send_trap(char *trap_name)
+int process_send_trap(const char *trap_name)
 {
 	int i;
 
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
 {
 	char usage_args[1024];
 	int mgmt_classes[2] = { IB_SMI_CLASS, IB_SMI_DIRECT_CLASS };
-	char *trap_name = NULL;
+	const char *trap_name = NULL;
 	int i, n, rc;
 
 	n = sprintf(usage_args, "[<trap_name>] [<error_port>]\n"

--- a/src/ibstat.c
+++ b/src/ibstat.c
@@ -54,7 +54,7 @@
 
 #include <ibdiag_common.h>
 
-static char *node_type_str[] = {
+static const char * const node_type_str[] = {
 	"???",
 	"CA",
 	"Switch",
@@ -82,7 +82,7 @@ static void ca_dump(umad_ca_t * ca)
 	       be64toh(ca->system_guid));
 }
 
-static char *port_state_str[] = {
+static const char * const port_state_str[] = {
 	"???",
 	"Down",
 	"Initializing",
@@ -90,7 +90,7 @@ static char *port_state_str[] = {
 	"Active"
 };
 
-static char *port_phy_state_str[] = {
+static const char * const port_phy_state_str[] = {
 	"No state change",
 	"Sleep",
 	"Polling",
@@ -110,8 +110,8 @@ static int ret_code(void)
 	return e;
 }
 
-static int sys_read_string(char *dir_name, char *file_name, char *str,
-			   int max_len)
+static int sys_read_string(const char *dir_name, const char *file_name,
+			   char *str, int max_len)
 {
 	char path[256], *s;
 	int fd, r;
@@ -163,8 +163,8 @@ done:
 
 static int port_dump(umad_port_t * port, int alone)
 {
-	char *pre = "";
-	char *hdrpre = "";
+	const char *pre = "";
+	const char *hdrpre = "";
 
 	if (!port)
 		return -1;

--- a/src/ibsysstat.c
+++ b/src/ibsysstat.c
@@ -257,7 +257,7 @@ static char *ibsystat(ib_portid_t * portid, int attr)
 	return 0;
 }
 
-int build_cpuinfo(void)
+static int build_cpuinfo(void)
 {
 	char line[1024] = { 0 }, *s, *e;
 	FILE *f;

--- a/src/ibtracert.c
+++ b/src/ibtracert.c
@@ -56,7 +56,7 @@ struct ibmad_port *srcport;
 
 #define MAXHOPS	63
 
-static char *node_type_str[] = {
+static const char * const node_type_str[] = {
 	"???",
 	"ca",
 	"switch",
@@ -214,7 +214,7 @@ static int extend_dpath(ib_dr_path_t * path, int nextport)
 	return path->cnt;
 }
 
-static void dump_endnode(int dump, char *prompt, Node * node, Port * port)
+static void dump_endnode(int dump, const char *prompt, Node *node, Port *port)
 {
 	char *nodename = NULL;
 

--- a/src/ibtracert.c
+++ b/src/ibtracert.c
@@ -740,12 +740,12 @@ free_name:
 	free(nodename);
 }
 
-static int resolve_lid(ib_portid_t * portid, const void *srcport)
+static int resolve_lid(ib_portid_t *portid)
 {
 	uint8_t portinfo[64] = { 0 };
 	uint16_t lid;
 
-	if (!smp_query_via(portinfo, portid, IB_ATTR_PORT_INFO, 0, 0, srcport))
+	if (!smp_query_via(portinfo, portid, IB_ATTR_PORT_INFO, 0, 0, NULL))
 		return -1;
 	mad_decode_field(portinfo, IB_PORT_LID_F, &lid);
 
@@ -804,12 +804,12 @@ static int get_route(char *srcid, char *dstid) {
 	}
 
 	if (ibd_dest_type == IB_DEST_DRPATH) {
-		if (resolve_lid(&src_portid, NULL) < 0) {
+		if (resolve_lid(&src_portid) < 0) {
 			IBWARN("cannot resolve lid for port \'%s\'",
 				portid2str(&src_portid));
 			return -1;
 		}
-		if (resolve_lid(&dest_portid, NULL) < 0) {
+		if (resolve_lid(&dest_portid) < 0) {
 			IBWARN("cannot resolve lid for port \'%s\'",
 				portid2str(&dest_portid));
 			return -1;

--- a/src/mcm_rereg_test.c
+++ b/src/mcm_rereg_test.c
@@ -63,7 +63,8 @@ static ibmad_gid_t mgid_ipoib = {
 
 struct ibmad_port *srcport;
 
-uint64_t build_mcm_rec(uint8_t * data, ibmad_gid_t mgid, ibmad_gid_t port_gid)
+static uint64_t build_mcm_rec(uint8_t *data, ibmad_gid_t mgid,
+			      ibmad_gid_t port_gid)
 {
 	memset(data, 0, IB_SA_DATA_SIZE);
 	mad_set_array(data, 0, IB_SA_MCM_MGID_F, mgid);

--- a/src/mcm_rereg_test.c
+++ b/src/mcm_rereg_test.c
@@ -51,7 +51,10 @@
 #ifdef NOISY_DEBUG
 #define dbg(fmt, ...) fprintf(stderr, "DBG: " fmt, ## __VA_ARGS__ )
 #else
-#define dbg(fmt, ...)
+__attribute__((format(printf, 1, 2))) static inline void dbg(const char *fmt,
+							     ...)
+{
+}
 #endif
 
 #define TMO 100

--- a/src/mcm_rereg_test.c
+++ b/src/mcm_rereg_test.c
@@ -309,8 +309,8 @@ static int rereg_query_all(int port, int agent, ib_portid_t * dport,
 
 #define MAX_CLIENTS 50
 
-static int rereg_and_test_port(char *guid_file, int port, int agent,
-			       ib_portid_t * dport, int timeout)
+static int rereg_and_test_port(const char *guid_file, int port, int agent,
+			       ib_portid_t *dport, int timeout)
 {
 	char line[256];
 	FILE *f;
@@ -356,9 +356,9 @@ static int rereg_and_test_port(char *guid_file, int port, int agent,
 	return 0;
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
-	char *guid_file = "port_guids.list";
+	const char *guid_file = "port_guids.list";
 	int mgmt_classes[2] = { IB_SMI_CLASS, IB_SMI_DIRECT_CLASS };
 	ib_portid_t dport_id;
 	int port, agent;

--- a/src/perfquery.c
+++ b/src/perfquery.c
@@ -686,7 +686,7 @@ static void vlxmittimecc_query(ib_portid_t * portid, int port, int mask)
 		    mad_dump_perfcounters_vl_xmit_time_cong);
 }
 
-void dump_portsamples_control(ib_portid_t * portid, int port)
+static void dump_portsamples_control(ib_portid_t *portid, int port)
 {
 	char buf[1280];
 

--- a/src/perfquery.c
+++ b/src/perfquery.c
@@ -453,12 +453,16 @@ static void reset_counters(int extended, int timeout, int mask,
 	}
 }
 
-static int reset, reset_only, all_ports, loop_ports, port, extended, xmt_sl,
-    rcv_sl, xmt_disc, rcv_err, extended_speeds, smpl_ctl, oprcvcounters, flowctlcounters,
-    vloppackets, vlopdata, vlxmitflowctlerrors, vlxmitcounters, swportvlcong,
-    rcvcc, slrcvfecn, slrcvbecn, xmitcc, vlxmittimecc;
-static int ports[MAX_PORTS];
-static int ports_count;
+static struct
+{
+	int reset, reset_only, all_ports, loop_ports, port, extended, xmt_sl,
+		rcv_sl, xmt_disc, rcv_err, extended_speeds, smpl_ctl,
+		oprcvcounters, flowctlcounters, vloppackets, vlopdata,
+		vlxmitflowctlerrors, vlxmitcounters, swportvlcong, rcvcc,
+		slrcvfecn, slrcvbecn, xmitcc, vlxmittimecc;
+	int ports[MAX_PORTS];
+	int ports_count;
+} info;
 
 static void common_func(ib_portid_t * portid, int port_num, int mask,
 			unsigned query, unsigned reset,
@@ -480,36 +484,38 @@ static void common_func(ib_portid_t * portid, int port_num, int mask,
 	}
 
 	memset(pc, 0, sizeof(pc));
-	if (reset && !performance_reset_via(pc, portid, port, mask, ibd_timeout,
-					    attr, srcport))
+	if (reset && !performance_reset_via(pc, portid, info.port, mask,
+					    ibd_timeout, attr, srcport))
 		IBEXIT("cannot reset %s", name);
 }
 
 static void xmt_sl_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortXmitDataSL", IB_GSI_PORT_XMIT_DATA_SL,
-		    mad_dump_perfcounters_xmt_sl);
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortXmitDataSL",
+		    IB_GSI_PORT_XMIT_DATA_SL, mad_dump_perfcounters_xmt_sl);
 }
 
 static void rcv_sl_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortRcvDataSL", IB_GSI_PORT_RCV_DATA_SL,
-		    mad_dump_perfcounters_rcv_sl);
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortRcvDataSL",
+		    IB_GSI_PORT_RCV_DATA_SL, mad_dump_perfcounters_rcv_sl);
 }
 
 static void xmt_disc_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortXmitDiscardDetails", IB_GSI_PORT_XMIT_DISCARD_DETAILS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortXmitDiscardDetails",
+		    IB_GSI_PORT_XMIT_DISCARD_DETAILS,
 		    mad_dump_perfcounters_xmt_disc);
 }
 
 static void rcv_err_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortRcvErrorDetails", IB_GSI_PORT_RCV_ERROR_DETAILS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortRcvErrorDetails",
+		    IB_GSI_PORT_RCV_ERROR_DETAILS,
 		    mad_dump_perfcounters_rcv_err);
 }
 
@@ -583,7 +589,7 @@ static void extended_speeds_query(ib_portid_t * portid, int port,
 {
 	int mask = ext_mask;
 
-	if (!reset_only) {
+	if (!info.reset_only) {
 		if (is_rsfec_mode_active(portid, port, cap_mask))
 			common_func(portid, port, mask, 1, 0,
 				    "PortExtendedSpeedsCounters with RS-FEC Active",
@@ -596,92 +602,103 @@ static void extended_speeds_query(ib_portid_t * portid, int port,
 			    mad_dump_port_ext_speeds_counters);
 	}
 
-	if ((reset_only || reset) &&
+	if ((info.reset_only || info.reset) &&
 	    !ext_speeds_reset_via(pc, portid, port, ext_mask, ibd_timeout))
 		IBEXIT("cannot reset PortExtendedSpeedsCounters");
 }
 
 static void oprcvcounters_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortOpRcvCounters", IB_GSI_PORT_PORT_OP_RCV_COUNTERS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortOpRcvCounters",
+		    IB_GSI_PORT_PORT_OP_RCV_COUNTERS,
 		    mad_dump_perfcounters_port_op_rcv_counters);
 }
 
 static void flowctlcounters_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortFlowCtlCounters", IB_GSI_PORT_PORT_FLOW_CTL_COUNTERS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortFlowCtlCounters",
+		    IB_GSI_PORT_PORT_FLOW_CTL_COUNTERS,
 		    mad_dump_perfcounters_port_flow_ctl_counters);
 }
 
 static void vloppackets_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortVLOpPackets", IB_GSI_PORT_PORT_VL_OP_PACKETS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortVLOpPackets",
+		    IB_GSI_PORT_PORT_VL_OP_PACKETS,
 		    mad_dump_perfcounters_port_vl_op_packet);
 }
 
 static void vlopdata_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortVLOpData", IB_GSI_PORT_PORT_VL_OP_DATA,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortVLOpData",
+		    IB_GSI_PORT_PORT_VL_OP_DATA,
 		    mad_dump_perfcounters_port_vl_op_data);
 }
 
 static void vlxmitflowctlerrors_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortVLXmitFlowCtlUpdateErrors", IB_GSI_PORT_PORT_VL_XMIT_FLOW_CTL_UPDATE_ERRORS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset),
+		    "PortVLXmitFlowCtlUpdateErrors",
+		    IB_GSI_PORT_PORT_VL_XMIT_FLOW_CTL_UPDATE_ERRORS,
 		    mad_dump_perfcounters_port_vl_xmit_flow_ctl_update_errors);
 }
 
 static void vlxmitcounters_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortVLXmitWaitCounters", IB_GSI_PORT_PORT_VL_XMIT_WAIT_COUNTERS,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortVLXmitWaitCounters",
+		    IB_GSI_PORT_PORT_VL_XMIT_WAIT_COUNTERS,
 		    mad_dump_perfcounters_port_vl_xmit_wait_counters);
 }
 
 static void swportvlcong_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "SwPortVLCongestion", IB_GSI_SW_PORT_VL_CONGESTION,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "SwPortVLCongestion",
+		    IB_GSI_SW_PORT_VL_CONGESTION,
 		    mad_dump_perfcounters_sw_port_vl_congestion);
 }
 
 static void rcvcc_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortRcvConCtrl", IB_GSI_PORT_RCV_CON_CTRL,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortRcvConCtrl",
+		    IB_GSI_PORT_RCV_CON_CTRL,
 		    mad_dump_perfcounters_rcv_con_ctrl);
 }
 
 static void slrcvfecn_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortSLRcvFECN", IB_GSI_PORT_SL_RCV_FECN,
-		    mad_dump_perfcounters_sl_rcv_fecn);
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortSLRcvFECN",
+		    IB_GSI_PORT_SL_RCV_FECN, mad_dump_perfcounters_sl_rcv_fecn);
 }
 
 static void slrcvbecn_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortSLRcvBECN", IB_GSI_PORT_SL_RCV_BECN,
-		    mad_dump_perfcounters_sl_rcv_becn);
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortSLRcvBECN",
+		    IB_GSI_PORT_SL_RCV_BECN, mad_dump_perfcounters_sl_rcv_becn);
 }
 
 static void xmitcc_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortXmitConCtrl", IB_GSI_PORT_XMIT_CON_CTRL,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortXmitConCtrl",
+		    IB_GSI_PORT_XMIT_CON_CTRL,
 		    mad_dump_perfcounters_xmit_con_ctrl);
 }
 
 static void vlxmittimecc_query(ib_portid_t * portid, int port, int mask)
 {
-	common_func(portid, port, mask, !reset_only, (reset_only || reset),
-		    "PortVLXmitTimeCong", IB_GSI_PORT_VL_XMIT_TIME_CONG,
+	common_func(portid, port, mask, !info.reset_only,
+		    (info.reset_only || info.reset), "PortVLXmitTimeCong",
+		    IB_GSI_PORT_VL_XMIT_TIME_CONG,
 		    mad_dump_perfcounters_vl_xmit_time_cong);
 }
 
@@ -703,74 +720,74 @@ static int process_opt(void *context, int ch, char *optarg)
 {
 	switch (ch) {
 	case 'x':
-		extended = 1;
+		info.extended = 1;
 		break;
 	case 'X':
-		xmt_sl = 1;
+		info.xmt_sl = 1;
 		break;
 	case 'S':
-		rcv_sl = 1;
+		info.rcv_sl = 1;
 		break;
 	case 'D':
-		xmt_disc = 1;
+		info.xmt_disc = 1;
 		break;
 	case 'E':
-		rcv_err = 1;
+		info.rcv_err = 1;
 		break;
 	case 'T':
-		extended_speeds = 1;
+		info.extended_speeds = 1;
 		break;
 	case 'c':
-		smpl_ctl = 1;
+		info.smpl_ctl = 1;
 		break;
 	case 1:
-		oprcvcounters = 1;
+		info.oprcvcounters = 1;
 		break;
 	case 2:
-		flowctlcounters = 1;
+		info.flowctlcounters = 1;
 		break;
 	case 3:
-		vloppackets = 1;
+		info.vloppackets = 1;
 		break;
 	case 4:
-		vlopdata = 1;
+		info.vlopdata = 1;
 		break;
 	case 5:
-		vlxmitflowctlerrors = 1;
+		info.vlxmitflowctlerrors = 1;
 		break;
 	case 6:
-		vlxmitcounters = 1;
+		info.vlxmitcounters = 1;
 		break;
 	case 7:
-		swportvlcong = 1;
+		info.swportvlcong = 1;
 		break;
 	case 8:
-		rcvcc = 1;
+		info.rcvcc = 1;
 		break;
 	case 9:
-		slrcvfecn = 1;
+		info.slrcvfecn = 1;
 		break;
 	case 10:
-		slrcvbecn = 1;
+		info.slrcvbecn = 1;
 		break;
 	case 11:
-		xmitcc = 1;
+		info.xmitcc = 1;
 		break;
 	case 12:
-		vlxmittimecc = 1;
+		info.vlxmittimecc = 1;
 		break;
 	case 'a':
-		all_ports++;
-		port = ALL_PORTS;
+		info.all_ports++;
+		info.port = ALL_PORTS;
 		break;
 	case 'l':
-		loop_ports++;
+		info.loop_ports++;
 		break;
 	case 'r':
-		reset++;
+		info.reset++;
 		break;
 	case 'R':
-		reset_only++;
+		info.reset_only++;
 		break;
 	default:
 		return -1;
@@ -850,10 +867,11 @@ int main(int argc, char **argv)
 		if (strchr(argv[1], ',')) {
 			tmpstr = strtok(argv[1], ",");
 			while (tmpstr) {
-				ports[ports_count++] = strtoul(tmpstr, 0, 0);
+				info.ports[info.ports_count++] =
+					strtoul(tmpstr, 0, 0);
 				tmpstr = strtok(NULL, ",");
 			}
-			port = ports[0];
+			info.port = info.ports[0];
 		}
 		else if ((tmpstr = strchr(argv[1], '-'))) {
 			int pmin, pmax;
@@ -868,12 +886,12 @@ int main(int argc, char **argv)
 				IBEXIT("max port must be greater than min port in range");
 
 			while (pmin <= pmax)
-				ports[ports_count++] = pmin++;
+				info.ports[info.ports_count++] = pmin++;
 
-			port = ports[0];
+			info.port = info.ports[0];
 		}
 		else
-			port = strtoul(argv[1], 0, 0);
+			info.port = strtoul(argv[1], 0, 0);
 	}
 	if (argc > 2) {
 		ext_mask = strtoull(argv[2], 0, 0);
@@ -891,13 +909,14 @@ int main(int argc, char **argv)
 				       ibd_dest_type, ibd_sm_id, srcport) < 0)
 			IBEXIT("can't resolve destination port %s", argv[0]);
 	} else {
-		if (resolve_self(ibd_ca, ibd_ca_port, &portid, &port, 0) < 0)
+		if (resolve_self(ibd_ca, ibd_ca_port, &portid, &info.port, 0) <
+		    0)
 			IBEXIT("can't resolve self port %s", argv[0]);
 	}
 
 	/* PerfMgt ClassPortInfo is a required attribute */
 	memset(pc, 0, sizeof(pc));
-	if (!pma_query_via(pc, &portid, port, ibd_timeout, CLASS_PORT_INFO,
+	if (!pma_query_via(pc, &portid, info.port, ibd_timeout, CLASS_PORT_INFO,
 			   srcport))
 		IBEXIT("classportinfo query");
 	/* ClassPortInfo should be supported as part of libibmad */
@@ -906,104 +925,104 @@ int main(int argc, char **argv)
 	cap_mask2 = ntohl(cap_mask2) >> 5;
 
 	if (!(cap_mask & IB_PM_ALL_PORT_SELECT)) {	/* bit 8 is AllPortSelect */
-		if (!all_ports && port == ALL_PORTS)
+		if (!info.all_ports && info.port == ALL_PORTS)
 			IBEXIT("AllPortSelect not supported");
-		if (all_ports && port == ALL_PORTS)
+		if (info.all_ports && info.port == ALL_PORTS)
 			all_ports_loop = 1;
 	}
 
-	if (xmt_sl) {
-		xmt_sl_query(&portid, port, mask);
+	if (info.xmt_sl) {
+		xmt_sl_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (rcv_sl) {
-		rcv_sl_query(&portid, port, mask);
+	if (info.rcv_sl) {
+		rcv_sl_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (xmt_disc) {
-		xmt_disc_query(&portid, port, mask);
+	if (info.xmt_disc) {
+		xmt_disc_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (rcv_err) {
-		rcv_err_query(&portid, port, mask);
+	if (info.rcv_err) {
+		rcv_err_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (extended_speeds) {
-		extended_speeds_query(&portid, port, ext_mask, cap_mask);
+	if (info.extended_speeds) {
+		extended_speeds_query(&portid, info.port, ext_mask, cap_mask);
 		goto done;
 	}
 
-	if (oprcvcounters) {
-		oprcvcounters_query(&portid, port, mask);
+	if (info.oprcvcounters) {
+		oprcvcounters_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (flowctlcounters) {
-		flowctlcounters_query(&portid, port, mask);
+	if (info.flowctlcounters) {
+		flowctlcounters_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (vloppackets) {
-		vloppackets_query(&portid, port, mask);
+	if (info.vloppackets) {
+		vloppackets_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (vlopdata) {
-		vlopdata_query(&portid, port, mask);
+	if (info.vlopdata) {
+		vlopdata_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (vlxmitflowctlerrors) {
-		vlxmitflowctlerrors_query(&portid, port, mask);
+	if (info.vlxmitflowctlerrors) {
+		vlxmitflowctlerrors_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (vlxmitcounters) {
-		vlxmitcounters_query(&portid, port, mask);
+	if (info.vlxmitcounters) {
+		vlxmitcounters_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (swportvlcong) {
-		swportvlcong_query(&portid, port, mask);
+	if (info.swportvlcong) {
+		swportvlcong_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (rcvcc) {
-		rcvcc_query(&portid, port, mask);
+	if (info.rcvcc) {
+		rcvcc_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (slrcvfecn) {
-		slrcvfecn_query(&portid, port, mask);
+	if (info.slrcvfecn) {
+		slrcvfecn_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (slrcvbecn) {
-		slrcvbecn_query(&portid, port, mask);
+	if (info.slrcvbecn) {
+		slrcvbecn_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (xmitcc) {
-		xmitcc_query(&portid, port, mask);
+	if (info.xmitcc) {
+		xmitcc_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (vlxmittimecc) {
-		vlxmittimecc_query(&portid, port, mask);
+	if (info.vlxmittimecc) {
+		vlxmittimecc_query(&portid, info.port, mask);
 		goto done;
 	}
 
-	if (smpl_ctl) {
-		dump_portsamples_control(&portid, port);
+	if (info.smpl_ctl) {
+		dump_portsamples_control(&portid, info.port);
 		goto done;
 	}
 
-
-	if (all_ports_loop || (loop_ports && (all_ports || port == ALL_PORTS))) {
+	if (all_ports_loop ||
+	    (info.loop_ports && (info.all_ports || info.port == ALL_PORTS))) {
 		if (!smp_query_via(data, &portid, IB_ATTR_NODE_INFO, 0, 0,
 				   srcport))
 			IBEXIT("smp query nodeinfo failed");
@@ -1021,35 +1040,35 @@ int main(int argc, char **argv)
 			if (enhancedport0)
 				start_port = 0;
 		}
-		if (all_ports_loop && !loop_ports)
+		if (all_ports_loop && !info.loop_ports)
 			IBWARN
 			    ("Emulating AllPortSelect by iterating through all ports");
 	}
 
-	if (reset_only)
+	if (info.reset_only)
 		goto do_reset;
 
-	if (all_ports_loop || (loop_ports && (all_ports || port == ALL_PORTS))) {
+	if (all_ports_loop ||
+	    (info.loop_ports && (info.all_ports || info.port == ALL_PORTS))) {
 		for (i = start_port; i <= num_ports; i++)
-			dump_perfcounters(extended, ibd_timeout,
-					  cap_mask, cap_mask2,
-					  &portid, i, (all_ports_loop
-						       && !loop_ports));
-		if (all_ports_loop && !loop_ports) {
-			if (extended != 1)
+			dump_perfcounters(info.extended, ibd_timeout, cap_mask,
+					  cap_mask2, &portid, i,
+					  (all_ports_loop && !info.loop_ports));
+		if (all_ports_loop && !info.loop_ports) {
+			if (info.extended != 1)
 				output_aggregate_perfcounters(&portid,
 							      cap_mask);
 			else
 				output_aggregate_perfcounters_ext(&portid,
 								  cap_mask, cap_mask2);
 		}
-	} else if (ports_count > 1) {
-		for (i = 0; i < ports_count; i++)
-			dump_perfcounters(extended, ibd_timeout, cap_mask,
-					  cap_mask2, &portid, ports[i],
-					  (all_ports && !loop_ports));
-		if (all_ports && !loop_ports) {
-			if (extended != 1)
+	} else if (info.ports_count > 1) {
+		for (i = 0; i < info.ports_count; i++)
+			dump_perfcounters(info.extended, ibd_timeout, cap_mask,
+					  cap_mask2, &portid, info.ports[i],
+					  (info.all_ports && !info.loop_ports));
+		if (info.all_ports && !info.loop_ports) {
+			if (info.extended != 1)
 				output_aggregate_perfcounters(&portid,
 							      cap_mask);
 			else
@@ -1057,21 +1076,21 @@ int main(int argc, char **argv)
 								  cap_mask, cap_mask2);
 		}
 	} else
-		dump_perfcounters(extended, ibd_timeout, cap_mask, cap_mask2,
-				  &portid, port, 0);
+		dump_perfcounters(info.extended, ibd_timeout, cap_mask,
+				  cap_mask2, &portid, info.port, 0);
 
-	if (!reset)
+	if (!info.reset)
 		goto done;
 
 do_reset:
-	if (argc <= 2 && !extended) {
+	if (argc <= 2 && !info.extended) {
 		if (cap_mask & IB_PM_PC_XMIT_WAIT_SUP)
 			mask |= (1 << 16);	/* reset portxmitwait */
 		if (cap_mask & IB_PM_IS_QP1_DROP_SUP)
 			mask |= (1 << 17);	/* reset qp1dropped */
 	}
 
-	if (extended) {
+	if (info.extended) {
 		mask |= 0xfff0000;
 		if (cap_mask & IB_PM_PC_XMIT_WAIT_SUP)
 			mask |= (1 << 28);
@@ -1079,14 +1098,17 @@ do_reset:
 			mask |= (1 << 29);
 	}
 
-	if (all_ports_loop || (loop_ports && (all_ports || port == ALL_PORTS))) {
+	if (all_ports_loop ||
+	    (info.loop_ports && (info.all_ports || info.port == ALL_PORTS))) {
 		for (i = start_port; i <= num_ports; i++)
-			reset_counters(extended, ibd_timeout, mask, &portid, i);
-	} else if (ports_count > 1) {
-		for (i = 0; i < ports_count; i++)
-			reset_counters(extended, ibd_timeout, mask, &portid, ports[i]);
+			reset_counters(info.extended, ibd_timeout, mask,
+				       &portid, i);
+	} else if (info.ports_count > 1) {
+		for (i = 0; i < info.ports_count; i++)
+			reset_counters(info.extended, ibd_timeout, mask,
+				       &portid, info.ports[i]);
 	} else
-		reset_counters(extended, ibd_timeout, mask, &portid, port);
+		reset_counters(info.extended, ibd_timeout, mask, &portid, info.port);
 
 done:
 	mad_rpc_close_port(srcport);

--- a/src/perfquery.c
+++ b/src/perfquery.c
@@ -514,8 +514,7 @@ static void rcv_err_query(ib_portid_t * portid, int port, int mask)
 }
 
 static uint8_t *ext_speeds_reset_via(void *rcvbuf, ib_portid_t * dest,
-				     int port, uint64_t mask, unsigned timeout,
-				     const struct ibmad_port * srcport)
+				     int port, uint64_t mask, unsigned timeout)
 {
 	ib_rpc_t rpc = { 0 };
 	int lid = dest->lid;
@@ -598,7 +597,7 @@ static void extended_speeds_query(ib_portid_t * portid, int port,
 	}
 
 	if ((reset_only || reset) &&
-	    !ext_speeds_reset_via(pc, portid, port, ext_mask, ibd_timeout, srcport))
+	    !ext_speeds_reset_via(pc, portid, port, ext_mask, ibd_timeout))
 		IBEXIT("cannot reset PortExtendedSpeedsCounters");
 }
 

--- a/src/sminfo.c
+++ b/src/sminfo.c
@@ -62,7 +62,7 @@ enum {
 	SMINFO_STATE_LAST,
 };
 
-char *statestr[] = {
+const char *const statestr[] = {
 	"SMINFO_NOTACT",
 	"SMINFO_DISCOVER",
 	"SMINFO_STANDBY",

--- a/src/smpdump.c
+++ b/src/smpdump.c
@@ -123,41 +123,6 @@ void smp_get_init(void *umad, int lid, int attr, int mod)
 	umad_set_addr(umad, lid, 0, 0, 0);
 }
 
-void drsmp_set_init(void *umad, DRPath * path, int attr, int mod, void *data)
-{
-	struct drsmp *smp = (struct drsmp *)(umad_get_mad(umad));
-
-	memset(smp, 0, sizeof(*smp));
-
-	smp->method = 2;	/* SET */
-	smp->attr_id = (uint16_t) htons((uint16_t) attr);
-	smp->attr_mod = htonl(mod);
-	smp->tid = htobe64(drmad_tid++);
-	smp->dr_slid = 0xffff;
-	smp->dr_dlid = 0xffff;
-
-	umad_set_addr(umad, 0xffff, 0, 0, 0);
-
-	if (path)
-		memcpy(smp->initial_path, path->path, path->hop_cnt + 1);
-
-	if (data)
-		memcpy(smp->data, data, sizeof smp->data);
-
-	smp->hop_cnt = (uint8_t) path->hop_cnt;
-}
-
-char *drmad_status_str(struct drsmp *drsmp)
-{
-	switch (drsmp->status) {
-	case 0:
-		return "success";
-	case ETIMEDOUT:
-		return "timeout";
-	}
-	return "unknown error";
-}
-
 int str2DRPath(char *str, DRPath * path)
 {
 	char *s;

--- a/src/smpdump.c
+++ b/src/smpdump.c
@@ -80,7 +80,7 @@ struct drsmp {
 	uint8_t return_path[64];
 };
 
-void drsmp_get_init(void *umad, DRPath * path, int attr, int mod)
+static void drsmp_get_init(void *umad, DRPath * path, int attr, int mod)
 {
 	struct drsmp *smp = (struct drsmp *)(umad_get_mad(umad));
 
@@ -105,7 +105,7 @@ void drsmp_get_init(void *umad, DRPath * path, int attr, int mod)
 	smp->hop_cnt = (uint8_t) path->hop_cnt;
 }
 
-void smp_get_init(void *umad, int lid, int attr, int mod)
+static void smp_get_init(void *umad, int lid, int attr, int mod)
 {
 	struct drsmp *smp = (struct drsmp *)(umad_get_mad(umad));
 
@@ -123,7 +123,7 @@ void smp_get_init(void *umad, int lid, int attr, int mod)
 	umad_set_addr(umad, lid, 0, 0, 0);
 }
 
-int str2DRPath(char *str, DRPath * path)
+static int str2DRPath(char *str, DRPath * path)
 {
 	char *s;
 

--- a/src/smpquery.c
+++ b/src/smpquery.c
@@ -76,7 +76,7 @@ static nn_map_t *node_name_map = NULL;
 static int extended_speeds = 0;
 
 /*******************************************/
-static char *node_desc(ib_portid_t * dest, char **argv, int argc)
+static const char *node_desc(ib_portid_t *dest, char **argv, int argc)
 {
 	int node_type, l;
 	uint64_t node_guid;
@@ -110,7 +110,7 @@ static char *node_desc(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *node_info(ib_portid_t * dest, char **argv, int argc)
+static const char *node_info(ib_portid_t * dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_SMP_DATA_SIZE] = { 0 };
@@ -124,7 +124,7 @@ static char *node_info(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *port_info_extended(ib_portid_t * dest, char **argv, int argc)
+static const char *port_info_extended(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
@@ -146,7 +146,7 @@ static char *port_info_extended(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *port_info(ib_portid_t * dest, char **argv, int argc)
+static const char *port_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char data[IB_SMP_DATA_SIZE] = { 0 };
 	int portnum = 0, orig_portnum;
@@ -165,7 +165,7 @@ static char *port_info(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *mlnx_ext_port_info(ib_portid_t * dest, char **argv, int argc)
+static const char *mlnx_ext_port_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2300];
 	char data[IB_SMP_DATA_SIZE];
@@ -183,7 +183,7 @@ static char *mlnx_ext_port_info(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *switch_info(ib_portid_t * dest, char **argv, int argc)
+static const char *switch_info(ib_portid_t *dest, char **argv, int argc)
 {
 	char buf[2048];
 	char data[IB_SMP_DATA_SIZE] = { 0 };
@@ -197,7 +197,7 @@ static char *switch_info(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *pkey_table(ib_portid_t * dest, char **argv, int argc)
+static const char *pkey_table(ib_portid_t *dest, char **argv, int argc)
 {
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
 	int i, j, k;
@@ -249,7 +249,7 @@ static char *pkey_table(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *sl2vl_dump_table_entry(ib_portid_t * dest, int in, int out)
+static const char *sl2vl_dump_table_entry(ib_portid_t *dest, int in, int out)
 {
 	char buf[2048];
 	char data[IB_SMP_DATA_SIZE] = { 0 };
@@ -264,12 +264,12 @@ static char *sl2vl_dump_table_entry(ib_portid_t * dest, int in, int out)
 	return 0;
 }
 
-static char *sl2vl_table(ib_portid_t * dest, char **argv, int argc)
+static const char *sl2vl_table(ib_portid_t *dest, char **argv, int argc)
 {
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
 	int type, num_ports, portnum = 0;
 	int i;
-	char *ret;
+	const char *ret;
 
 	if (argc > 0)
 		portnum = strtol(argv[0], 0, 0);
@@ -299,8 +299,8 @@ static char *sl2vl_table(ib_portid_t * dest, char **argv, int argc)
 	return 0;
 }
 
-static char *vlarb_dump_table_entry(ib_portid_t * dest, int portnum, int offset,
-				    unsigned cap)
+static const char *vlarb_dump_table_entry(ib_portid_t *dest, int portnum,
+					  int offset, unsigned cap)
 {
 	char buf[2048];
 	char data[IB_SMP_DATA_SIZE] = { 0 };
@@ -313,10 +313,10 @@ static char *vlarb_dump_table_entry(ib_portid_t * dest, int portnum, int offset,
 	return 0;
 }
 
-static char *vlarb_dump_table(ib_portid_t * dest, int portnum,
-			      char *name, int offset, int cap)
+static const char *vlarb_dump_table(ib_portid_t *dest, int portnum,
+				    const char *name, int offset, int cap)
 {
-	char *ret;
+	const char *ret;
 
 	printf("# %s priority VL Arbitration Table:", name);
 	ret = vlarb_dump_table_entry(dest, portnum, offset,
@@ -327,12 +327,12 @@ static char *vlarb_dump_table(ib_portid_t * dest, int portnum,
 	return ret;
 }
 
-static char *vlarb_table(ib_portid_t * dest, char **argv, int argc)
+static const char *vlarb_table(ib_portid_t *dest, char **argv, int argc)
 {
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
 	int portnum = 0;
 	int type, enhsp0, lowcap, highcap;
-	char *ret = 0;
+	const char *ret = NULL;
 
 	if (argc > 0)
 		portnum = strtol(argv[0], 0, 0);
@@ -378,7 +378,7 @@ static char *vlarb_table(ib_portid_t * dest, char **argv, int argc)
 	return ret;
 }
 
-static char *guid_info(ib_portid_t * dest, char **argv, int argc)
+static const char *guid_info(ib_portid_t *dest, char **argv, int argc)
 {
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
 	int i, j, k;
@@ -437,7 +437,7 @@ int main(int argc, char **argv)
 	int mgmt_classes[3] =
 	    { IB_SMI_CLASS, IB_SMI_DIRECT_CLASS, IB_SA_CLASS };
 	ib_portid_t portid = { 0 };
-	char *err;
+	const char *err;
 	op_fn_t *fn;
 	const match_rec_t *r;
 	int n;

--- a/src/vendstat.c
+++ b/src/vendstat.c
@@ -175,9 +175,8 @@ static int is_ext_fw_info_supported(uint16_t device_id) {
 	return 0;
 }
 
-static int do_vendor(ib_portid_t *portid, struct ibmad_port *srcport,
-		     uint8_t class, uint8_t method, uint16_t attr_id,
-		     uint32_t attr_mod, void *data)
+static int do_vendor(ib_portid_t *portid, uint8_t class, uint8_t method,
+		     uint16_t attr_id, uint32_t attr_mod, void *data)
 {
 	ib_vendor_call_t call;
 
@@ -208,7 +207,7 @@ static int do_config_space_records(ib_portid_t *portid, unsigned set,
 		cs->record[i].mask = htonl(cs->record[i].mask);
 	}
 
-	if (do_vendor(portid, srcport, IB_MLX_VENDOR_CLASS,
+	if (do_vendor(portid, IB_MLX_VENDOR_CLASS,
 		      set ? IB_MAD_METHOD_SET : IB_MAD_METHOD_GET,
 		      IB_MLX_IS3_CONFIG_SPACE_ACCESS, 2 << 22 | records << 16,
 		      cs)) {
@@ -231,7 +230,7 @@ static int counter_groups_info(ib_portid_t * portid, int port)
 
 	/* Counter Group Info */
 	memset(&buf, 0, sizeof(buf));
-	if (do_vendor(portid, srcport, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
+	if (do_vendor(portid, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
 		      IB_MLX_IS4_COUNTER_GROUP_INFO, port, buf)) {
 		fprintf(stderr,"counter group info query failure\n");
 		return -1;
@@ -271,7 +270,7 @@ static int config_counter_groups(ib_portid_t * portid, int port)
 	cg_config->group_selects[0].group_select = (uint8_t) cg0;
 	cg_config->group_selects[1].group_select = (uint8_t) cg1;
 
-	if (do_vendor(portid, srcport, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_SET,
+	if (do_vendor(portid, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_SET,
 		      IB_MLX_IS4_CONFIG_COUNTER_GROUP, port, buf)) {
 		fprintf(stderr, "config counter group set failure\n");
 		return -1;
@@ -279,7 +278,7 @@ static int config_counter_groups(ib_portid_t * portid, int port)
 	/* get config counter groups */
 	memset(&buf, 0, sizeof(buf));
 
-	if (do_vendor(portid, srcport, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
+	if (do_vendor(portid, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
 		      IB_MLX_IS4_CONFIG_COUNTER_GROUP, port, buf)) {
 		fprintf(stderr, "config counter group query failure\n");
 		return -1;
@@ -436,14 +435,14 @@ int main(int argc, char **argv)
 
 	/* vendor ClassPortInfo is required attribute if class supported */
 	memset(&buf, 0, sizeof(buf));
-	if (do_vendor(&portid, srcport, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
+	if (do_vendor(&portid, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
 		      CLASS_PORT_INFO, 0, buf)) {
 		mad_rpc_close_port(srcport);
 		IBEXIT("classportinfo query");
 	}
 	memset(&buf, 0, sizeof(buf));
 	gi_is3 = (is3_general_info_t *) &buf;
-	if (do_vendor(&portid, srcport, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
+	if (do_vendor(&portid, IB_MLX_VENDOR_CLASS, IB_MAD_METHOD_GET,
 		      IB_MLX_IS3_GENERAL_INFO, 0, gi_is3)) {
 		mad_rpc_close_port(srcport);
 		IBEXIT("generalinfo query");
@@ -499,7 +498,7 @@ int main(int argc, char **argv)
 		for (i = 0; i < 16; i++)
 			cs->record[i].address =
 			    htonl(IB_MLX_IS3_PORT_XMIT_WAIT + ((i + 1) << 12));
-		if (do_vendor(&portid, srcport, IB_MLX_VENDOR_CLASS,
+		if (do_vendor(&portid, IB_MLX_VENDOR_CLASS,
 			      IB_MAD_METHOD_GET, IB_MLX_IS3_CONFIG_SPACE_ACCESS,
 			      2 << 22 | 16 << 16, cs)) {
 			mad_rpc_close_port(srcport);
@@ -516,7 +515,7 @@ int main(int argc, char **argv)
 		for (i = 0; i < 8; i++)
 			cs->record[i].address =
 			    htonl(IB_MLX_IS3_PORT_XMIT_WAIT + ((i + 17) << 12));
-		if (do_vendor(&portid, srcport, IB_MLX_VENDOR_CLASS,
+		if (do_vendor(&portid, IB_MLX_VENDOR_CLASS,
 			      IB_MAD_METHOD_GET, IB_MLX_IS3_CONFIG_SPACE_ACCESS,
 			      2 << 22 | 8 << 16, cs)) {
 			mad_rpc_close_port(srcport);


### PR DESCRIPTION
When running on a higher warning level the compiler throws lots of interesting warnings out, fix a bunch of them.

This brings infiniband-diags to a level where it build warning free with the same warnings flags that rdma-core uses by default on latest compilers.