### PR TITLE
RPM spec: Download source from github.com/linux-rdma/infiniband-diags

### DIFF
--- a/infiniband-diags.spec.in
+++ b/infiniband-diags.spec.in
@@ -9,8 +9,8 @@ Release: %rel%{?dist}
 License: GPLv2 or BSD
 Group: System Environment/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Source: http://www.openfabrics.org/downloads/management/@TARBALL@
-Url: http://openfabrics.org/
+Source: https://github.com/linux-rdma/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+Url: https://github.com/linux-rdma/%{name}/
 BuildRequires: opensm-devel, libibumad-devel, glib2-devel
 Requires: opensm-libs, libibumad, glib2
 Provides: perl(IBswcountlimits)


### PR DESCRIPTION
Create the RPM file from source files at github.com/linux-rdma/infiniband-diags instead of http://www.openfabrics.org because the link on http://www.openfabrics.org is dead.

Once this PR is merged, can one create a git tag "2.2.0" to make a new release with all fixes since last year?