### PR TITLE
ibdiags: Use cl_qmap instead of glib hashtable

### DIFF
--- a/README
+++ b/README
@@ -13,8 +13,7 @@ Dependencies:
 	1) libibumad >= 1.3.7
 	2) opensm-libs >= 3.3.10
 	3) ib_umad kernel module
-	4) glib2
-	
+
 Python dependencies:
 	1) docutils
 

--- a/configure.ac
+++ b/configure.ac
@@ -155,15 +155,6 @@ IBSCRIPTPATH_TMP2="`echo $IBSCRIPTPATH_TMP1 | sed 's/^NONE/$ac_default_prefix/'`
 IBSCRIPTPATH="${with_ibpath_override:-`eval echo $IBSCRIPTPATH_TMP2`}"
 AC_SUBST(IBSCRIPTPATH)
 
-dnl check for glib
-PKG_CHECK_MODULES([GLIB], [glib-2.0], ac_glib=yes, ac_glib=no)
-AM_CONDITIONAL([HAVE_GLIB], test "$ac_glib" = "yes")
-if test "$ac_glib" = "yes"; then
-   AC_DEFINE([HAVE_GLIB], 1, [Define to 1 to indicate GLIB support])
-else
-   AC_MSG_ERROR(glib not found; glib2 is required)
-fi
-
 dnl Begin libibnetdisc stuff
 ibnetdisc_api_version=`grep LIBVERSION $srcdir/libibnetdisc/libibnetdisc.ver | sed 's/LIBVERSION=//'`
 if test -z $ibnetdisc_api_version; then

--- a/infiniband-diags.spec.in
+++ b/infiniband-diags.spec.in
@@ -11,8 +11,8 @@ Group: System Environment/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Source: https://github.com/linux-rdma/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 Url: https://github.com/linux-rdma/%{name}/
-BuildRequires: opensm-devel, libibumad-devel, glib2-devel
-Requires: opensm-libs, libibumad, glib2
+BuildRequires: opensm-devel, libibumad-devel
+Requires: opensm-libs, libibumad
 Provides: perl(IBswcountlimits)
 Obsoletes: openib-diags
 Provides: libibmad = %{version}-%{release}

--- a/libibnetdisc/Makefile.am
+++ b/libibnetdisc/Makefile.am
@@ -25,10 +25,10 @@ endif
 
 libibnetdisc_la_SOURCES = src/ibnetdisc.c src/ibnetdisc_cache.c src/chassis.c \
 			  src/chassis.h src/internal.h src/query_smp.c
-libibnetdisc_la_CFLAGS = -Wall $(DBGFLAGS) $(GLIB_CFLAGS)
+libibnetdisc_la_CFLAGS = -Wall $(DBGFLAGS)
 libibnetdisc_la_LDFLAGS = -version-info $(ibnetdisc_api_version) \
 	-export-dynamic $(libibnetdisc_version_script) \
-	-L$(top_builddir)/libibmad -libmad $(GLIB_LIBS)
+	-L$(top_builddir)/libibmad -libmad
 libibnetdisc_la_DEPENDENCIES = $(srcdir)/src/libibnetdisc.map
 
 libibnetdiscincludedir = $(includedir)/infiniband

--- a/libibnetdisc/src/ibnetdisc_cache.c
+++ b/libibnetdisc/src/ibnetdisc_cache.c
@@ -614,7 +614,7 @@ static int _rebuild_ports(ibnd_fabric_cache_t * fabric_cache)
 		} else
 			port->remoteport = NULL;
 
-		add_to_portlid_hash(port, fabric_cache->f_int->lid2guid);
+		add_to_portlid_hash(port, fabric_cache->f_int);
 		port_cache = port_cache_next;
 	}
 

--- a/libibnetdisc/src/internal.h
+++ b/libibnetdisc/src/internal.h
@@ -40,7 +40,6 @@
 
 #include <infiniband/ibnetdisc.h>
 #include <complib/cl_qmap.h>
-#include <glib.h>
 
 #define	IBND_DEBUG(fmt, ...) \
 	if (ibdebug) { \
@@ -60,12 +59,12 @@
 
 typedef struct f_internal {
 	ibnd_fabric_t fabric;
-	GHashTable *lid2guid;
+	cl_qmap_t lid2guid;
 } f_internal_t;
 f_internal_t *allocate_fabric_internal(void);
 void create_lid2guid(f_internal_t *f_int);
 void destroy_lid2guid(f_internal_t *f_int);
-void add_to_portlid_hash(ibnd_port_t * port, GHashTable *htable);
+void add_to_portlid_hash(ibnd_port_t * port, f_internal_t *f_int);
 
 typedef struct ibnd_scan {
 	ib_portid_t selfportid;


### PR DESCRIPTION
These do basically the same thing for this purpose, no reason to have a
glib dependency for such a simple data structure.

Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>